### PR TITLE
Add container-based task example

### DIFF
--- a/examples/container.py
+++ b/examples/container.py
@@ -1,0 +1,15 @@
+"""This example showcases how to run a container, rather than a Python, function, as the payload of a task in Hera"""
+from hera.v1.task import Task
+from hera.v1.workflow import Workflow
+from hera.v1.workflow_service import WorkflowService
+
+# TODO: replace the domain and token with your own
+ws = WorkflowService('my-argo-server.com', 'my-auth-token')
+w = Workflow('fv-testing', ws)
+
+# notice the placeholder `lambda: _`, for now this is required because
+# func is a required parameter, by design. Perhaps this can be made
+# `Optional[Callable]` in the future
+t = Task('cowsay', lambda: _, image='docker/whalesay', command=['cowsay', 'foo'])
+w.add_task(t)
+w.submit()


### PR DESCRIPTION
Issue #20 asked about the idea of running a container or a bash script inside a task. An example was offered in the discussion. This PR adds that example to the `examples` directory of Hera.