### PR TITLE
Refactor `Config` to allow host and SSL specifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ The general format is:
 
 - location of all files from `v1` up one folder to `hera`. Now everything will take the import form
   of `from hera.module import Object` rather than `from hera.v1.module import Object`
+- interface of services to take a full host rather than a single domain and put in effort to compute the final host.
+  This will offer more freedom to users to select their own host scheme, for example. A flag for SSL verification was
+  also introduced
 
 # 0.4.0 - DATE (15/12/2021)
 

--- a/conftest.py
+++ b/conftest.py
@@ -4,18 +4,35 @@ import pytest
 from pydantic import BaseModel
 
 from hera.artifact import InputArtifact, OutputArtifact
+from hera.cron_workflow import CronWorkflow
+from hera.cron_workflow_service import CronWorkflowService
 from hera.workflow import Workflow
 from hera.workflow_service import WorkflowService
 
 
 @pytest.fixture(scope='session')
 def ws():
-    yield WorkflowService('abc.com', 'abc')
+    yield WorkflowService(host='https://abc.com', token='abc')
 
 
 @pytest.fixture(scope='function')
 def w(ws):
     yield Workflow('w', service=ws)
+
+
+@pytest.fixture(scope='function')
+def cws():
+    yield CronWorkflowService(host='https://abc.com', token='abc')
+
+
+@pytest.fixture(scope='session')
+def schedule():
+    yield "* * * * *"
+
+
+@pytest.fixture(scope='function')
+def cw(cws, schedule):
+    yield CronWorkflow('cw', schedule, service=cws)
 
 
 @pytest.fixture(scope='session')

--- a/src/hera/config.py
+++ b/src/hera/config.py
@@ -1,5 +1,6 @@
 """Holds the configurations required for submitting workflows to the Argo server"""
 import os
+from typing import Optional
 
 import urllib3
 from argo.workflows.client import Configuration as ArgoConfig
@@ -16,13 +17,31 @@ class Config:
 
     Parameters
     ----------
-    domain: str
-        The domain of the Argo
+    host: Optional[str] = None
+        The host of the Argo server to submit workflows to. An attempt to assemble a host from Argo K8S cluster
+        environment variables is pursued if this is not specified.
+    verify_ssl: bool = True
+        Whether to perform SSL/TLS verification. Set this to false to skip verifying SSL certificate when submitting
+        workflows from an HTTPS server.
     """
 
-    def __init__(self, domain: str):
-        self._domain = domain
-        self._config = self.__get_config()
+    def __init__(self, host: Optional[str] = None, verify_ssl: bool = True):
+        self._host = host or self._assemble_host()
+        self._verify_ssl = verify_ssl
+
+    def _assemble_host(self):
+        """Assembles a host from the default K8S cluster env variables with Argo's address.
+
+        Notes
+        -----
+        The pod containers should have an environment variable with the address of the Argo server, and this is
+        # the default one. Users who wish to assemble this on their own can do so and submit the result via the `host`
+        """
+        tcp_addr = os.getenv('ARGO_SERVER_PORT_2746_TCP_ADDR', None)
+        assert tcp_addr is not None, 'A configuration/service host is required for submitting workflows'
+
+        tcp_port = os.getenv('ARGO_SERVER_PORT_2746_TCP_PORT', None)
+        return f'https://{tcp_addr}:{tcp_port}' if tcp_port else f'https://{tcp_addr}'
 
     def __get_config(self) -> ArgoConfig:
         """Assembles the Argo configuration.
@@ -37,28 +56,10 @@ class Config:
         to force skip SSL verification on the ApiClient side (Argo client inside the containers of the ArgoApi clients)
         for otherwise the connection fails.
 
-        Use this together with Client to instantiate a WorkflowServiceApi.
+        Use this together with Client to instantiate a WorkflowService/CronWorkflowService.
         """
-        scheme = 'https'
-        config = ArgoConfig()
-
-        argo_tcp_addr = os.getenv('ARGO_SERVER_PORT_2746_TCP_ADDR')
-        if argo_tcp_addr:
-            host = argo_tcp_addr
-        else:
-            host = self._domain
-
-        if host != self._domain:
-            port = os.getenv('ARGO_SERVER_PORT_2746_TCP_PORT')
-            # K8S deployments in a namespace that has an Argo deployment get Argo specific environment variables,
-            # so this _should_ be safe
-            assert port, 'unspecified port'
-            config.verify_ssl = False
-        else:
-            port = ''
-
-        addr = f'{scheme}://{host}:{port}' if port else f'{scheme}://{host}'
-        config.host = addr
+        config = ArgoConfig(host=self._host)
+        config.verify_ssl = self._verify_ssl
         return config
 
     @property

--- a/src/hera/config.py
+++ b/src/hera/config.py
@@ -28,6 +28,7 @@ class Config:
     def __init__(self, host: Optional[str] = None, verify_ssl: bool = True):
         self._host = host or self._assemble_host()
         self._verify_ssl = verify_ssl
+        self._config = self.__get_config()
 
     def _assemble_host(self):
         """Assembles a host from the default K8S cluster env variables with Argo's address.

--- a/src/hera/cron_workflow_service.py
+++ b/src/hera/cron_workflow_service.py
@@ -1,5 +1,5 @@
 """Holds the cron workflow service that supports client cron workflow creations"""
-from typing import Tuple, Optional
+from typing import Optional, Tuple
 
 from argo.workflows.client import (
     CronWorkflowServiceApi,
@@ -32,11 +32,17 @@ class CronWorkflowService:
         This defaults to the `default` namespace.
     """
 
-    def __init__(self, host: Optional[str] = None, verify_ssl: bool = True, token: Optional[str] = None,
-                 namespace: str = 'default'):
+    def __init__(
+        self,
+        host: Optional[str] = None,
+        verify_ssl: bool = True,
+        token: Optional[str] = None,
+        namespace: str = 'default',
+    ):
         self._host = host
+        self._verify_ssl = verify_ssl
         self._namespace = namespace
-        api_client = Client(Config(host=self._host, verify_ssl=verify_ssl), token).api_client
+        api_client = Client(Config(host=self._host, verify_ssl=self._verify_ssl), token).api_client
         self.service = CronWorkflowServiceApi(api_client=api_client)
 
     def create(self, cron_workflow: V1alpha1CronWorkflow, namespace: str = 'default') -> V1alpha1CronWorkflow:

--- a/src/hera/workflow_service.py
+++ b/src/hera/workflow_service.py
@@ -1,5 +1,5 @@
 """Holds the workflow service that supports client workflow submissions"""
-from typing import Tuple
+from typing import Optional, Tuple
 
 from argo.workflows.client import (
     V1alpha1Workflow,
@@ -16,19 +16,31 @@ class WorkflowService:
 
     Parameters
     ----------
-    domain: str
-        The Argo deployment domain to submit workflows to.
-    token: str
+    host: Optional[str] = None
+        The host of the Argo server to submit workflows to. An attempt to assemble a host from Argo K8S cluster
+        environment variables is pursued if this is not specified.
+    verify_ssl: bool = True
+        Whether to perform SSL/TLS verification. Set this to false to skip verifying SSL certificate when submitting
+        workflows from an HTTPS server.
+    token: Optional[str] = None
         The token to use for authentication purposes. Note that this assumes the Argo deployment is fronted with a
         deployment/service that can intercept a request and check the Bearer token.
     namespace: str = 'default'
-        The K8S namespace the workflow service submits workflows to. This defaults to the `default` namespace.
+        The K8S namespace the cron workflow service creates cron workflows in.
+        This defaults to the `default` namespace.
     """
 
-    def __init__(self, domain: str, token: str, namespace: str = 'default'):
-        self._domain = domain
+    def __init__(
+        self,
+        host: Optional[str] = None,
+        verify_ssl: bool = True,
+        token: Optional[str] = None,
+        namespace: str = 'default',
+    ):
+        self._host = host
+        self._verify_ssl = verify_ssl
         self._namespace = namespace
-        api_client = Client(Config(domain), token).api_client
+        api_client = Client(Config(host=self._host, verify_ssl=self._verify_ssl), token).api_client
         self.service = WorkflowServiceApi(api_client=api_client)
 
     def submit(self, workflow: V1alpha1Workflow, namespace: str = 'default') -> V1alpha1Workflow:
@@ -78,4 +90,4 @@ class WorkflowService:
         str
             The workflow link.
         """
-        return f'https://{self._domain}/workflows/{self._namespace}/{name}?tab=workflow'
+        return f'{self._host}/workflows/{self._namespace}/{name}?tab=workflow'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,9 +11,9 @@ def test_config_contains_env_host():
 
     expected_addr = 'https://address:port'
 
-    config = Config('')
+    config = Config()
     assert config.config.host == expected_addr
-    assert not config.config.verify_ssl
+    assert config.config.verify_ssl
 
     # deleting env vars since it influences the session and other tests
     del os.environ['ARGO_SERVER_PORT_2746_TCP_ADDR']
@@ -21,10 +21,7 @@ def test_config_contains_env_host():
 
 
 def test_config_contains_domain_host():
-    mock_domain = 'domain.com'
-
-    expected_addr = 'https://domain.com'
-
-    config = Config(mock_domain)
-    assert config.config.host == expected_addr
-    assert config.config.verify_ssl
+    host = 'http://argo.com'
+    config = Config(host=host, verify_ssl=False)
+    assert config.config.host == host
+    assert not config.config.verify_ssl

--- a/tests/test_cron_workflow.py
+++ b/tests/test_cron_workflow.py
@@ -1,31 +1,9 @@
-import pytest
-
 from hera.cron_workflow import CronWorkflow
-from hera.cron_workflow_service import CronWorkflowService
 from hera.empty_dir_volume import EmptyDirVolume
 from hera.existing_volume import ExistingVolume
 from hera.resources import Resources
 from hera.task import Task
 from hera.volume import Volume
-
-
-@pytest.fixture
-def cws():
-    yield CronWorkflowService('abc.com', 'abc')
-
-
-@pytest.fixture
-def schedule():
-    yield "* * * * *"
-
-
-@pytest.fixture
-def cw(cws, schedule):
-    yield CronWorkflow('cw', schedule, service=cws)
-
-
-def noop():
-    pass
 
 
 def test_wf_contains_specified_service_account(cws, schedule):
@@ -51,9 +29,9 @@ def test_cwf_does_not_add_empty_task(cw):
     assert not cw.dag_template.tasks
 
 
-def test_cwf_adds_specified_tasks(cw):
+def test_cwf_adds_specified_tasks(cw, no_op):
     n = 3
-    ts = [Task(f't{i}', noop) for i in range(n)]
+    ts = [Task(f't{i}', no_op) for i in range(n)]
     cw.add_tasks(*ts)
 
     assert len(cw.dag_template.tasks) == n
@@ -61,10 +39,10 @@ def test_cwf_adds_specified_tasks(cw):
         assert ts[i].name == t.name
 
 
-def test_cwf_adds_task_volume(cw):
+def test_cwf_adds_task_volume(cw, no_op):
     t = Task(
         't',
-        noop,
+        no_op,
         resources=Resources(volume=Volume(name='v', size='1Gi', mount_path='/', storage_class_name='custom')),
     )
     cw.add_task(t)
@@ -76,8 +54,8 @@ def test_cwf_adds_task_volume(cw):
     assert claim.metadata.name == 'v'
 
 
-def test_cwf_adds_task_existing_checkpoints_staging_volume(cw):
-    t = Task('t', noop, resources=Resources(existing_volume=ExistingVolume(name='v', mount_path='/')))
+def test_cwf_adds_task_existing_checkpoints_staging_volume(cw, no_op):
+    t = Task('t', no_op, resources=Resources(existing_volume=ExistingVolume(name='v', mount_path='/')))
     cw.add_task(t)
 
     vol = cw.spec.volumes[0]
@@ -85,10 +63,10 @@ def test_cwf_adds_task_existing_checkpoints_staging_volume(cw):
     assert vol.persistent_volume_claim.claim_name == 'v'
 
 
-def test_cwf_adds_task_existing_checkpoints_prod_volume(cw):
+def test_cwf_adds_task_existing_checkpoints_prod_volume(cw, no_op):
     t = Task(
         't',
-        noop,
+        no_op,
         resources=Resources(existing_volume=ExistingVolume(name='vol', mount_path='/')),
     )
     cw.add_task(t)
@@ -98,8 +76,8 @@ def test_cwf_adds_task_existing_checkpoints_prod_volume(cw):
     assert vol.persistent_volume_claim.claim_name == 'vol'
 
 
-def test_cwf_adds_task_empty_dir_volume(cw):
-    t = Task('t', noop, resources=Resources(empty_dir_volume=EmptyDirVolume(name='v')))
+def test_cwf_adds_task_empty_dir_volume(cw, no_op):
+    t = Task('t', no_op, resources=Resources(empty_dir_volume=EmptyDirVolume(name='v')))
     cw.add_task(t)
 
     vol = cw.spec.volumes[0]
@@ -108,26 +86,26 @@ def test_cwf_adds_task_empty_dir_volume(cw):
     assert vol.empty_dir.medium == 'Memory'
 
 
-def test_cwf_adds_head(cw):
-    t1 = Task('t1', noop)
-    t2 = Task('t2', noop)
+def test_cwf_adds_head(cw, no_op):
+    t1 = Task('t1', no_op)
+    t2 = Task('t2', no_op)
     t1.next(t2)
     cw.add_tasks(t1, t2)
 
-    h = Task('head', noop)
+    h = Task('head', no_op)
     cw.add_head(h)
 
     assert t1.argo_task.dependencies == ['head']
     assert t2.argo_task.dependencies == ['t1', 'head']
 
 
-def test_cwf_adds_tail(cw):
-    t1 = Task('t1', noop)
-    t2 = Task('t2', noop)
+def test_cwf_adds_tail(cw, no_op):
+    t1 = Task('t1', no_op)
+    t2 = Task('t2', no_op)
     t1.next(t2)
     cw.add_tasks(t1, t2)
 
-    t = Task('tail', noop)
+    t = Task('tail', no_op)
     cw.add_tail(t)
 
     assert not t1.argo_task.dependencies
@@ -135,19 +113,19 @@ def test_cwf_adds_tail(cw):
     assert t.argo_task.dependencies == ['t2']
 
 
-def test_cwf_overwrites_head_and_tail(cw):
-    t1 = Task('t1', noop)
-    t2 = Task('t2', noop)
+def test_cwf_overwrites_head_and_tail(cw, no_op):
+    t1 = Task('t1', no_op)
+    t2 = Task('t2', no_op)
     t1.next(t2)
     cw.add_tasks(t1, t2)
 
-    h2 = Task('head2', noop)
+    h2 = Task('head2', no_op)
     cw.add_head(h2)
 
     assert t1.argo_task.dependencies == ['head2']
     assert t2.argo_task.dependencies == ['t1', 'head2']
 
-    h1 = Task('head1', noop)
+    h1 = Task('head1', no_op)
     cw.add_head(h1)
 
     assert h2.argo_task.dependencies == ['head1']


### PR DESCRIPTION
There are multiple use cases in which users would get value out of choosing their own host/scheme combo, along with SSL verification behavior. This PR refactors the `Config` object:
- removes `domain` with `host` full specifications, so users can have complete control over this
- adds scheme/domain/port inference conditionally
- adds a `verify_ssl` flag
- makes host spec optional so that it's clear users can rely on the env variables exposed by Argo in their own K8S cluster

Fixes: #40, merging into branch for #41 