### PR TITLE
WIP: Add option to override unique name generation for Workflow and CronWorkflow

### DIFF
--- a/src/hera/workflow.py
+++ b/src/hera/workflow.py
@@ -36,6 +36,10 @@ class Workflow:
         A Dict of labels to attach to the Workflow object metadata
     namespace: Optional[str] = 'default'
         The namespace to use for creating the Workflow.  Defaults to "default"
+    use_unique_name: Optional[bool] = True
+        Flag to indicate whether the name should be made unique by appending a uuid4() substring.
+        Defaults to True to preserve existing functionality.
+        Note that the V1alpha1Template name will continue to use the unique name.
     """
 
     def __init__(
@@ -46,8 +50,12 @@ class Workflow:
         service_account_name: Optional[str] = None,
         labels: Optional[Dict[str, str]] = None,
         namespace: Optional[str] = 'default',
+        use_unique_name: Optional[bool] = True,
     ):
-        self.name = f'{name.replace("_", "-")}-{str(uuid4()).split("-")[0]}'  # RFC1123
+        self.name = name.replace("_", "-")
+        self.unique_name = f'{self.name}-{str(uuid4()).split("-")[0]}'
+        if use_unique_name:
+            self.name = self.unique_name
         self.namespace = namespace
         self.service = service
         self.parallelism = parallelism
@@ -56,7 +64,7 @@ class Workflow:
 
         self.dag_template = V1alpha1DAGTemplate(tasks=[])
         self.template = V1alpha1Template(
-            name=self.name,
+            name=self.unique_name,
             steps=[],
             dag=self.dag_template,
             parallelism=self.parallelism,

--- a/tests/test_cron_workflow.py
+++ b/tests/test_cron_workflow.py
@@ -195,3 +195,18 @@ def test_cwf_suspend_with_defaults(ws):
     w.service = Mock()
     w.suspend()
     w.service.suspend.assert_called_with(w.name, w.namespace)
+
+
+def test_cwf_contains_unique_name(ws):
+    w = CronWorkflow('w', schedule="* * * * *", service=ws, labels={'foo': 'bar'}, namespace="test")
+    expected_name = 'w'
+    assert w.name != expected_name
+
+
+def test_cwf_contains_specified_name(ws):
+    w = CronWorkflow(
+        'w', schedule="* * * * *", service=ws, labels={'foo': 'bar'}, namespace="test", use_unique_name=False
+    )
+    expected_name = 'w'
+    assert w.name == w.metadata.name == expected_name
+    assert w.template.name != expected_name

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -154,3 +154,16 @@ def test_wf_submit_with_default(ws):
     w.service = Mock()
     w.submit()
     w.service.submit.assert_called_with(w.workflow, w.namespace)
+
+
+def test_wf_contains_unique_name(ws):
+    w = Workflow('w', service=ws, labels={'foo': 'bar'}, namespace="test")
+    expected_name = 'w'
+    assert w.name != expected_name
+
+
+def test_wf_contains_specified_name(ws):
+    w = Workflow('w', service=ws, labels={'foo': 'bar'}, namespace="test", use_unique_name=False)
+    expected_name = 'w'
+    assert w.name == w.metadata.name == expected_name
+    assert w.template.name != expected_name


### PR DESCRIPTION
@flaviuvadan Let me know what you think of this idea.   It preserves the existing unique name functionality and provides the ability to keep the name specified by the caller unchanged if so desired.  If you agree I'll add the VERSION and CHANGELOG entries once I know where in the flight pattern it will land.

Thanks