### PR TITLE
Workaround for duplicate task creation

### DIFF
--- a/src/hera/env.py
+++ b/src/hera/env.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any, Optional
 
 from argo_workflows.models import (
@@ -10,6 +9,7 @@ from argo_workflows.models import (
 from pydantic import BaseModel, validator
 
 from hera.validators import json_serializable
+from hera.json_utils import encode_json
 
 
 class EnvSpec(BaseModel):
@@ -20,11 +20,9 @@ class EnvSpec(BaseModel):
     name: str
         The name of the variable.
     value: Optional[Any] = None
-        The value of the variable. This value is serialized for the client. If a pydantic BaseModel is passed in the
-        corresponding `.json()` method will be used for serialization. It is up to the client to deserialize the value
-        in the task. In addition, if another type is passed, covered by `Any`, an attempt at `json.dumps` will be
-        performed.
-
+        The value of the variable. This value is serialized for the client.
+        This uses hera.json_utils.encode_json to encode the supplied value to
+        json.
     Raises
     ------
     AssertionError
@@ -43,12 +41,7 @@ class EnvSpec(BaseModel):
     @property
     def argo_spec(self) -> EnvVar:
         """Constructs and returns the Argo environment specification"""
-        if isinstance(self.value, BaseModel):
-            value = self.value.json()
-        elif isinstance(self.value, str):
-            value = self.value
-        else:
-            value = json.dumps(self.value)
+        value = encode_json(self.value)
         return EnvVar(name=self.name, value=value)
 
 

--- a/src/hera/json_utils.py
+++ b/src/hera/json_utils.py
@@ -1,0 +1,26 @@
+import json
+from typing import Union, Dict, List
+
+from pydantic import BaseModel
+
+
+JSONType = Union[None, BaseModel, bool, str, float, int, List['JSONType'], Dict[str, 'JSONType']]  # type: ignore
+
+
+def encode_json(value: JSONType) -> str:
+    if isinstance(value, BaseModel):
+        return value.json()
+    elif isinstance(value, str):
+        return value
+    else:
+        return json.dumps(value)
+
+
+def create_param_extraction(param_name: str) -> str:
+    return f"""
+try:
+    {param_name} = json.loads('''{{{{inputs.parameters.{param_name}}}}}''')
+except json.JSONDecodeError:
+    # Edge case for when parameter is a bare string
+    {param_name} = '{{{{inputs.parameters.{param_name}}}}}'
+"""


### PR DESCRIPTION
Due to argoproj/argo-workflows#7895, when creating parallel tasks using `withItems` where an item is a single-quote-surrounded json string (ie: `'"foo"'`), duplicate tasks get executed.

This PR is a workaround by avoiding sending json-encoded strings and instead using the native-string type supported by argo. This also introduces the need for error checking in the resulting script and may break backwards compatibility for anyone rewriting `Task.get_param_script_portion`.

Resolves #98 

Also, :confetti_ball: for 100th issue/pr!