### PR TITLE
Remove artifact uploads

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -100,7 +100,7 @@ jobs:
 
       - name: twine check
         run: |
-          twine check .tox/dist/*
+          twine check dist/*
 
       - name: upload build artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -96,7 +96,7 @@ jobs:
 
       - name: list artifacts
         run: |
-          ls -l .tox/dist
+          ls -l dist
 
       - name: twine check
         run: |

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -57,11 +57,13 @@ jobs:
         run: |
           twine check .tox/dist/*
 
-      - name: upload build artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: pypi-build-arts
-          path: .tox/dist
+# TODO: wheels for linux_x86_64 cannot be uploaded. Rather, this needs manylinux distributions, which can be installed
+# TODO: via cibuildwheel
+#      - name: upload build artifacts
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: pypi-build-arts
+#          path: .tox/dist
 
       - name: upload coverage files
         uses: actions/upload-artifact@v2
@@ -90,7 +92,7 @@ jobs:
 
       - name: build sdist and wheel ( no test )
         run: |
-          python -m build --sdist --wheel --outdir .tox/dist/
+          python -m build --sdist --wheel
 
       - name: list artifacts
         run: |
@@ -104,7 +106,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: pypi-build-arts
-          path: .tox/dist
+          path: dist
 
   coverage:
     needs: [ test ]


### PR DESCRIPTION
[Recent CICD improvements](https://github.com/argoproj-labs/hera-workflows/pull/101) resulted in upload failures because the built wheels do not use a `manylinux` type. @harelwa [suggested](https://github.com/argoproj-labs/hera-workflows/pull/101#issuecomment-1079996290) commenting out the upload part for now until we figure out how to create the necessary wheel types.