### PR TITLE
Use separate poetry build and twine upload step 

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -139,7 +139,8 @@ jobs:
 
       - name: Build and publish
         env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+          PYPI_USERNAME: __token__
+          PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: |
-          poetry publish --build --username $TWINE_USERNAME --password $TWINE_PASSWORD
+          poetry build
+          twine upload -u __token__ -p $PYPI_PASSWORD --skip-existing dist/* 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "hera"
+name = "hera-workflows"
 version = "2.8.1"
 description="Hera is a Python framework for constructing and submitting Argo Workflows. The main goal of Hera is to make Argo Workflows more accessible by abstracting away some setup that is typically necessary for constructing Argo workflows."
 authors = ["Flaviu Vadan <flaviu.vadan@dynotx.com>"]


### PR DESCRIPTION
The package publish failed in [this build](https://github.com/argoproj-labs/hera-workflows/runs/5885199764?check_suite_focus=true) because the project aimed to publish Hera at https://pypi.org/project/hera rather than https://pypi.org/project/hera-workflows. This PR changes the name of the project to fix that. Also, the publication step will fail for versions that do not change the project version. To get around that, this adds a skip existing flag to the publication process. Note that poetry does not support a skip existing flag so the command was separated out into a poetry build step and a twine upload step.