### PR TITLE
Support cluster_scope in TemplateRef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ The general format is:
 
 ```
 
+# 3.2.0 - DATE (03/05/2022)
+
+### Added
+
+- support `cluster_scope` in template reference
+
 # 3.1.0 - DATE (28/04/2022)
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hera-workflows"
-version = "3.1.0"
+version = "3.2.0"
 description="Hera is a Python framework for constructing and submitting Argo Workflows. The main goal of Hera is to make Argo Workflows more accessible by abstracting away some setup that is typically necessary for constructing Argo workflows."
 authors = ["Flaviu Vadan <flaviu.vadan@dynotx.com>"]
 license = "MIT"

--- a/src/hera/template_ref.py
+++ b/src/hera/template_ref.py
@@ -11,11 +11,16 @@ class TemplateRef(BaseModel):
         The name of the workflow template reference.
     template: str
         The name of the independent task template to reference in the workflow template.
+    cluster_scope: bool = False
+        Whether the referenced template is cluster scoped or not.
     """
 
     name: str
     template: str
+    cluster_scope: bool = False
 
     @property
     def argo_spec(self) -> IoArgoprojWorkflowV1alpha1TemplateRef:
-        return IoArgoprojWorkflowV1alpha1TemplateRef(name=self.name, template=self.template)
+        return IoArgoprojWorkflowV1alpha1TemplateRef(
+            name=self.name, template=self.template, cluster_scope=self.cluster_scope
+        )


### PR DESCRIPTION
`IoArgoprojWorkflowV1alpha1TemplateRef` allows setting cluster_scope.

https://github.com/argoproj/argo-workflows/blob/master/sdks/python/client/docs/IoArgoprojWorkflowV1alpha1TemplateRef.md

TemplateRef can now set cluster_scope as well.

(I left the default value of cluster_scope as False so as not to affect existing scripts. What do you think?)