### PR TITLE
Clean up for task template ref

### DIFF
--- a/src/hera/task.py
+++ b/src/hera/task.py
@@ -46,7 +46,7 @@ from hera.retry import Retry
 from hera.security_context import TaskSecurityContext
 from hera.template_ref import TemplateRef
 from hera.toleration import Toleration
-from hera.variable import VariableAsEnv
+from hera.variable import Variable, VariableAsEnv
 
 
 class _Item(ModelSimple):
@@ -214,7 +214,7 @@ class Task:
         A Dict of labels to attach to the Task Template object metadata.
     annotations: Optional[Dict[str, str]] = None
         A Dict of annotations to attach to the Task Template object metadata.
-    variables: Optional[List[VariableAsEnv]] = None
+    variables: Optional[List[Variable]] = None
         A list of variable for a Task. Allows passing information about other Tasks into this Task.
     security_context: Optional[TaskSecurityContext] = None
         Define security settings for the task container, overrides workflow security context.
@@ -255,7 +255,7 @@ class Task:
         node_selectors: Optional[Dict[str, str]] = None,
         labels: Optional[Dict[str, str]] = None,
         annotations: Optional[Dict[str, str]] = None,
-        variables: Optional[List[VariableAsEnv]] = None,
+        variables: Optional[List[Variable]] = None,
         security_context: Optional[TaskSecurityContext] = None,
         continue_on_fail: bool = False,
         continue_on_error: bool = False,

--- a/src/hera/variable.py
+++ b/src/hera/variable.py
@@ -7,16 +7,15 @@ from pydantic import BaseModel
 from hera.env import EnvSpec
 
 
-class VariableAsEnv(BaseModel):
-    """This allows passing information into a Task from another Task, as an environment variables.
-    As an example, you can pass a secondary Tasks IP address, to the Task.
+class Variable(BaseModel):
+    """This allows passing variable into a Task.
 
     Parameters
     ----------
     name: str
-        The name of the environment variable abailable inside the Task.
+        The name of the variable available inside the Task.
     value: str
-        The value to be set for the environment variable. This could be something like Task.ip
+        The value to be set for the variable.
     """
 
     name: str
@@ -27,6 +26,24 @@ class VariableAsEnv(BaseModel):
 
     def get_input_parameter(self):
         return IoArgoprojWorkflowV1alpha1Inputs(name=self.name)
+
+
+class VariableAsEnv(Variable):
+    """This allows passing information into a Task from another Task, as an environment variables.
+    As an example, you can pass a secondary Tasks IP address, to the Task.
+
+    Parameters
+    ----------
+    name: str
+        The name of the environment variable abailable inside the Task.
+    value: str
+        The value to be set for the environment variable. This could be something like Task.ip
+
+    Notes
+    -----
+        If you use template_ref in Task, you don't need to use VariableAsEnv, just use Variable.
+        VariableAsEnv is for ScriptTemplate or Container.
+    """
 
     def get_env_spec(self):
         return EnvSpec(name=self.name, value=f"{{{{inputs.parameters.{self.name}}}}}")

--- a/src/hera/workflow_editors.py
+++ b/src/hera/workflow_editors.py
@@ -24,7 +24,8 @@ def add_tasks(w: Union['WorkflowTemplate', 'CronWorkflow', 'Workflow'], *ts: Tas
         return
 
     for t in ts:
-        w.spec.templates.append(t.argo_template)
+        if t.template_ref is None:
+            w.spec.templates.append(t.argo_template)
 
         if t.resources.volumes:
             for vol in t.resources.volumes:

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -6,6 +6,7 @@ from argo_workflows.model.pod_security_context import PodSecurityContext
 from hera.resources import Resources
 from hera.security_context import WorkflowSecurityContext
 from hera.task import Task
+from hera.template_ref import TemplateRef
 from hera.ttl_strategy import TTLStrategy
 from hera.volumes import (
     ConfigMapVolume,
@@ -235,3 +236,14 @@ def test_wf_adds_ttl_strategy(ws):
     }
 
     assert w.spec.ttl_strategy._data_store == expected_ttl_strategy
+
+
+def test_wf_add_task_with_template_ref(w):
+    t = Task("t", template_ref=TemplateRef(name="name", template="template"))
+    w.add_task(t)
+
+    assert w.dag_template.tasks[0] == t.argo_task
+
+    # Not add a Task with TemplateRef to w.spec.templates
+    # Note: w.spec.templates[0] is a template of dag
+    assert len(w.spec.templates) == 1


### PR DESCRIPTION
* (1) When using Task.template_ref, the existing implementation adds unnecessary templates to WorkflowSpec.templates.
Changed to not add template to WorkflowSpec.templates when using template_ref.
* (2) If using variables in Task.template_ref, there is no need to add a variable to `env`.
Variable and VariableAsEnv are separated so that users can choose which to use.


Regarding (1), the following code adds t1 and t2 to WorkflowSpec.templates, but these are unnecessary.

```python
w = Workflow(
    "use-hello-template-in-task-by-hera",
    ws,
    namespace=namespace,
    service_account_name=service_account,
)

t1 = Task(
    "t1", template_ref=TemplateRef(name="hello-template", template="hello-template")
)
t2 = Task(
    "t2",
    template_ref=TemplateRef(
        name="hello-template", template="hello-template-with-parameters"
    ),
    variables=[VariableAsEnv(name="message", value="hello world from t2!")],
)
t1 >> t2
w.add_tasks(t1, t2)
```

```json
{
  "templates": [
    {
      "name": "use-hello-template-in-task-by-hera",
      "steps": [],
      "dag": {
        "tasks": [
          {
            "name": "t1",
            "continue_on": {
              "error": false,
              "failed": false
            },
            "arguments": {
              "parameters": [],
              "artifacts": []
            },
            "template_ref": {
              "name": "hello-template",
              "template": "hello-template"
            }
          },
          {
            "name": "t2",
            "continue_on": {
              "error": false,
              "failed": false
            },
            "arguments": {
              "parameters": [
                {
                  "name": "message",
                  "value": "hello world from t2!"
                }
              ],
              "artifacts": []
            },
            "template_ref": {
              "name": "hello-template",
              "template": "hello-template-with-parameters"
            },
            "dependencies": [
              "t1"
            ]
          }
        ]
      },
      "parallelism": 50,
      "service_account_name": "argo"
    },
    {
      "name": "t1",
      "daemon": false,
      "inputs": {
        "parameters": [],
        "artifacts": []
      },
      "outputs": {
        "artifacts": []
      },
      "tolerations": [],
      "metadata": {
        "labels": {},
        "annotations": {}
      },
      "container": {
        "image": "python:3.7",
        "image_pull_policy": "Always",
        "command": [
          "python"
        ],
        "volume_mounts": [],
        "resources": {
          "requests": {
            "cpu": "1",
            "memory": "4Gi"
          },
          "limits": {
            "cpu": "1",
            "memory": "4Gi"
          }
        },
        "env": [],
        "env_from": []
      }
    },
    {
      "name": "t2",
      "daemon": false,
      "inputs": {
        "parameters": [
          {
            "name": "message",
            "value": "hello world from t2!"
          }
        ],
        "artifacts": []
      },
      "outputs": {
        "artifacts": []
      },
      "tolerations": [],
      "metadata": {
        "labels": {},
        "annotations": {}
      },
      "container": {
        "image": "python:3.7",
        "image_pull_policy": "Always",
        "command": [
          "python"
        ],
        "volume_mounts": [],
        "resources": {
          "requests": {
            "cpu": "1",
            "memory": "4Gi"
          },
          "limits": {
            "cpu": "1",
            "memory": "4Gi"
          }
        },
        "env": [
          {
            "name": "message",
            "value": "{{inputs.parameters.message}}"
          }
        ],
        "env_from": []
      }
    }
  ],
  "entrypoint": "use-hello-template-in-task-by-hera",
  "volumes": [],
  "volume_claim_templates": [],
  "service_account_name": "argo"
}
```