### PR TITLE
Add task template mechanism 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ The general format is:
 ### Added
 
 - support `cluster_scope` in template reference
+- add implementation for `TaskTemplates` - this enables specifying task details with a template once and creating task
+  based on that template instead of redefining every time
 
 # 3.1.0 - DATE (28/04/2022)
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Currently, Hera is centered around two core concepts. These concepts are also us
 consistent with:
 
 - `Task` - the object that holds the Python function for remote execution/the atomic unit of execution;
+- `TaskTemplate` - allows specifying task once and reusing with different arguments;
 - `Workflow` - the higher level representation of a collection of tasks.
 
 # Examples

--- a/examples/diamond_task_template.py
+++ b/examples/diamond_task_template.py
@@ -55,13 +55,7 @@ b = task_template.task('B-task', [{'message': 'This is task B!'}])
 c = task_template.task('C-task', [{'other_message': 'This is task C!'}])
 d = task_template.task(
     'D-task',
-    [
-        {
-            'message': {
-                "dicted": "message with non-alpanumeric characters: !@#$%^&*()_-+=;|<.>/?"
-            }
-        }
-    ],
+    [{'message': {"dicted": "message with non-alpanumeric characters: !@#$%^&*()_-+=;|<.>/?"}}],
 )
 
 a.next(b)  # a >> b

--- a/examples/diamond_task_template.py
+++ b/examples/diamond_task_template.py
@@ -1,0 +1,73 @@
+"""
+This example showcases the classic diamond workflow that is used as an example by Argo documentation and
+other libraries but with the use of TaskTemplate.
+
+TaskTemplate provides the same functionality as Task with the exception that one TaskTemplate could generate
+other tasks that would have their definition stated once and just invoked with arguments.
+
+This makes the workflow size smaller by reusing task templates in tasks. Also, it improves consistency and
+allows specifying default values for tasks.
+"""
+from hera.task_template import TaskTemplate
+from hera.workflow import Workflow
+from hera.workflow_service import WorkflowService
+
+
+def say(message: str, other_message: str):
+    print(f"message: {message}")
+    print(f"other_message: {other_message}")
+
+
+# TODO: replace the domain and token with your own
+ws = WorkflowService(host='https://my-argo-server.com', token='my-auth-token')
+w = Workflow('diamond-task-template', ws)
+
+# NOTE: task_template is specified once and invocations of task_template.task(...)
+# provide only task name and args.
+task_template = TaskTemplate(
+    'A',
+    say,
+    [
+        {
+            'message': "default value for param 'message'",
+            "other_message": {"default": {"value": {"for": "other_message"}}},
+        }
+    ],
+)
+
+a = task_template.task(
+    'A-task',
+    [
+        {
+            'message': 'This is task A-0!',
+            "other_message": (
+                "Providing list of args greater than 1 uses "
+                "'withItems' mechanism and needs all params to be specified"
+            ),
+        },
+        {
+            'message': 'This is task A-1!',
+            "other_message": "This is other_message for A-1!",
+        },
+    ],
+)
+b = task_template.task('B-task', [{'message': 'This is task B!'}])
+c = task_template.task('C-task', [{'other_message': 'This is task C!'}])
+d = task_template.task(
+    'D-task',
+    [
+        {
+            'message': {
+                "dicted": "message with non-alpanumeric characters: !@#$%^&*()_-+=;|<.>/?"
+            }
+        }
+    ],
+)
+
+a.next(b)  # a >> b
+a.next(c)  # a >> c
+b.next(d)  # b >> d
+c.next(d)  # c >> d
+
+w.add_tasks(a, b, c, d)
+w.create()

--- a/src/hera/task_template.py
+++ b/src/hera/task_template.py
@@ -1,0 +1,41 @@
+import json
+from typing import Optional, List, Dict, Union
+
+from pydantic import BaseModel
+
+from hera.artifact import Artifact
+from hera.input import InputFrom
+from hera.task import Task
+from hera.variable import VariableAsEnv
+
+
+class TaskTemplate(Task):
+    def task(
+        self,
+        name: str,
+        func_params: Optional[
+            List[Dict[str, Union[int, str, float, dict, BaseModel]]]
+        ] = None,
+        input_from: Optional[InputFrom] = None,
+        input_artifacts: Optional[List[Artifact]] = None,
+    ) -> Task:
+        task = Task(
+            name=self.name,
+            func_params=func_params,
+            input_from=input_from,
+            input_artifacts=input_artifacts,
+        )
+        task.name = name.replace("_", "-")  # RFC1123
+        task.argo_template = self.argo_template
+
+        task.variables = [
+            VariableAsEnv(name=key, value=json.dumps(value))
+            for param in func_params
+            for key, value in param.items()
+        ]
+        task.parameters = task.get_parameters()
+        task.argo_input_artifacts = task.get_argo_input_artifacts()
+
+        task.arguments = task.get_arguments()
+        task.argo_task = task.get_task_spec()
+        return task

--- a/src/hera/task_template.py
+++ b/src/hera/task_template.py
@@ -42,11 +42,9 @@ class TaskTemplate(Task):
         )
         name = name or self.name
         task.name = name.replace("_", "-")  # RFC1123
-        task.argo_template = self.argo_template
-
-        # Needed for Task.get_task_template which is already defined for self.
         task.env_from = self.env_from
         task.env = self.env
+        task.argo_template = self.argo_template
 
         # Reload task spec with reused template.
         task.argo_task = task.get_task_spec()

--- a/src/hera/task_template.py
+++ b/src/hera/task_template.py
@@ -1,4 +1,5 @@
 from typing import Dict, List, Optional, Union
+
 from pydantic import BaseModel
 
 from hera.artifact import Artifact

--- a/src/hera/task_template.py
+++ b/src/hera/task_template.py
@@ -1,5 +1,5 @@
 import json
-from typing import Optional, List, Dict, Union
+from typing import Dict, List, Optional, Union
 
 from pydantic import BaseModel
 
@@ -13,9 +13,7 @@ class TaskTemplate(Task):
     def task(
         self,
         name: str,
-        func_params: Optional[
-            List[Dict[str, Union[int, str, float, dict, BaseModel]]]
-        ] = None,
+        func_params: Optional[List[Dict[str, Union[int, str, float, dict, BaseModel]]]] = None,
         input_from: Optional[InputFrom] = None,
         input_artifacts: Optional[List[Artifact]] = None,
     ) -> Task:
@@ -31,10 +29,7 @@ class TaskTemplate(Task):
         func_params = func_params or []
         if len(func_params) > 1:
             uniq_keys = {key for param in func_params for key in param.keys()}
-            task.variables = [
-                VariableAsEnv(name=key, value=f"{{{{item.{key}}}}}")
-                for key in uniq_keys
-            ]
+            task.variables = [VariableAsEnv(name=key, value=f"{{{{item.{key}}}}}") for key in uniq_keys]
         else:
             task.variables = [
                 VariableAsEnv(name=key, value=json.dumps(value))

--- a/src/hera/task_template.py
+++ b/src/hera/task_template.py
@@ -28,11 +28,20 @@ class TaskTemplate(Task):
         task.name = name.replace("_", "-")  # RFC1123
         task.argo_template = self.argo_template
 
-        task.variables = [
-            VariableAsEnv(name=key, value=json.dumps(value))
-            for param in func_params
-            for key, value in param.items()
-        ]
+        func_params = func_params or []
+        if len(func_params) > 1:
+            uniq_keys = {key for param in func_params for key in param.keys()}
+            task.variables = [
+                VariableAsEnv(name=key, value=f"{{{{item.{key}}}}}")
+                for key in uniq_keys
+            ]
+        else:
+            task.variables = [
+                VariableAsEnv(name=key, value=json.dumps(value))
+                for param in func_params[:1]
+                for key, value in param.items()
+            ]
+
         task.parameters = task.get_parameters()
         task.argo_input_artifacts = task.get_argo_input_artifacts()
 

--- a/src/hera/task_template.py
+++ b/src/hera/task_template.py
@@ -12,19 +12,29 @@ from hera.variable import VariableAsEnv
 class TaskTemplate(Task):
     def task(
         self,
-        name: str,
+        name: str = None,
         func_params: Optional[List[Dict[str, Union[int, str, float, dict, BaseModel]]]] = None,
         input_from: Optional[InputFrom] = None,
         input_artifacts: Optional[List[Artifact]] = None,
     ) -> Task:
         task = Task(
             name=self.name,
-            func_params=func_params,
-            input_from=input_from,
-            input_artifacts=input_artifacts,
+            func=self.func,
+            func_params=func_params or self.func_params,
+            resources=self.resources,
+            template_ref=self.template_ref,
+            retry=self.retry,
+            continue_on_fail=self.continue_on_fail,
+            continue_on_error=self.continue_on_error,
+            input_from=input_from or self.input_from,
+            input_artifacts=input_artifacts or self.input_artifacts,
+            variables=self.variables,
         )
+        name = name or self.name
         task.name = name.replace("_", "-")  # RFC1123
         task.argo_template = self.argo_template
+
+        task.func = self.func
 
         func_params = func_params or []
         if len(func_params) > 1:

--- a/src/hera/workflow_editors.py
+++ b/src/hera/workflow_editors.py
@@ -24,16 +24,18 @@ def add_tasks(w: Union['WorkflowTemplate', 'CronWorkflow', 'Workflow'], *ts: Tas
         return
 
     for t in ts:
-        if t.template_ref is None:
+        if t.template_ref is None and t.argo_template not in w.spec.templates:
             w.spec.templates.append(t.argo_template)
 
         if t.resources.volumes:
             for vol in t.resources.volumes:
                 if isinstance(vol, Volume):
                     # dynamically provisioned volumes need associated claims on the workflow spec
-                    w.spec.volume_claim_templates.append(vol.get_claim_spec())
+                    if vol.get_claim_spec() not in w.spec.volume_claim_templates:
+                        w.spec.volume_claim_templates.append(vol.get_claim_spec())
                 else:
-                    w.spec.volumes.append(vol.get_volume())
+                    if vol.get_volume() not in w.spec.volumes:
+                        w.spec.volumes.append(vol.get_volume())
 
         w.dag_template.tasks.append(t.argo_task)
 

--- a/tests/test_task_template.py
+++ b/tests/test_task_template.py
@@ -1,4 +1,4 @@
-from hera.task_template import TaskTemplate  # noqa
+from hera.task_template import TaskTemplate
 from test_task import task_security_context_kwargs  # noqa
 import inspect
 import test_task
@@ -29,14 +29,14 @@ for test_name in _test_func_names:
     modified_lines = lines.replace("Task(", "TaskTemplate(")
     exec(modified_lines)
 
-# Modify all tests to use TaskTemplate(...).task
+# Modify all tests to use TaskTemplate(...).task.
 for test_name in _test_func_names:
     f = test_task.__getattribute__(test_name)
     lines = inspect.getsource(f)
     lines = lines.splitlines()
 
     for index, line in enumerate(lines):
-        # either first or second line because of @pytest decorators
+        # Not always first line because of @pytest decorators.
         if line.startswith("def"):
             def_line = line.replace("test_", "test_templated_")
             lines[index] = def_line

--- a/tests/test_task_template.py
+++ b/tests/test_task_template.py
@@ -1,10 +1,10 @@
-from hera.task_template import TaskTemplate
-from test_task import task_security_context_kwargs  # noqa
 import inspect
-import test_task
-
 from pathlib import Path
 
+import test_task
+from test_task import task_security_context_kwargs  # noqa
+
+from hera.task_template import TaskTemplate
 
 # Get test_task.py path into Path.
 test_task_file = Path(__file__).parent.joinpath("test_task.py")
@@ -23,11 +23,7 @@ def create_task_from_templated_task(*args, **kwargs):
 
 # Get all imports from test_task.py and import here.
 with open(test_task_file, "r") as file:
-    imports = [
-        line
-        for line in file.readlines()
-        if line.startswith("from ") or line.startswith("import ")
-    ]
+    imports = [line for line in file.readlines() if line.startswith("from ") or line.startswith("import ")]
     for i in imports:
         exec(i)
 
@@ -56,7 +52,5 @@ for test_name in _test_func_names:
             lines[index] = def_line
 
     modified_source = "\n".join(lines)
-    modified_source = modified_source.replace(
-        "Task(", f"{create_task_from_templated_task.__name__}("
-    )
+    modified_source = modified_source.replace("Task(", f"{create_task_from_templated_task.__name__}(")
     exec(modified_source)

--- a/tests/test_task_template.py
+++ b/tests/test_task_template.py
@@ -1,0 +1,24 @@
+from hera.task_template import TaskTemplate  # noqa
+from test_task import task_security_context_kwargs  # noqa
+import inspect
+import test_task
+
+# Get all imports from test_task.py and import here.
+with open("tests/test_task.py", "r") as file:
+    imports = [
+        line
+        for line in file.readlines()
+        if line.startswith("from ") or line.startswith("import ")
+    ]
+    for i in imports:
+        # print(i)
+        exec(i)
+
+
+# Get all tests defined in test_task.py and modify to use TaskTemplate.
+_test_func_names = [test for test in test_task.__dir__() if test.startswith("test")]
+for test_name in _test_func_names:
+    f = test_task.__getattribute__(test_name)
+    lines = inspect.getsource(f)
+    modified_lines = lines.replace("Task(", "TaskTemplate(")
+    exec(modified_lines)

--- a/tests/test_task_template.py
+++ b/tests/test_task_template.py
@@ -60,31 +60,58 @@ def test_one_template_two_tasks(op):
     tmpl = TaskTemplate("tmpl", op, [{"a": 1}])
 
     t1 = tmpl.task("t1")
-    t2 = tmpl.task("t2", [{"a": 3}])
+    t2 = tmpl.task("t2", [{"a": 2}])
 
-    assert tmpl.name == "tmpl", "TaskTemplate name mismatch"
-    assert t1.name == "t1", "t1 name mismatch"
-    assert t2.name == "t2", "t2 name mismatch"
+    assert tmpl.name == "tmpl"
+    assert t1.name == "t1"
+    assert t2.name == "t2"
 
     for p_tmpl in tmpl.get_parameters():
-        assert p_tmpl.name == "a", "TaskTemplate param name mismatch"
-        assert p_tmpl.value == "1", "TaskTemplate default param value mismatch"
+        assert p_tmpl.name == "a"
+        assert p_tmpl.value == "1"
 
     for t1_p in t1.get_parameters():
-        assert t1_p.name == "a", "t1 param name mismatch"
-        assert t1_p.value == "1", "t1 default param value mismatch"
+        assert t1_p.name == "a"
+        assert t1_p.value == "1"
 
     for t2_p in t2.get_parameters():
-        assert t2_p.name == "a", "t2 param name mismatch"
-        assert t2_p.value == "3", "t2 param value mismatch"
+        assert t2_p.name == "a"
+        assert t2_p.value == "2"
 
 
-def test_two_templates_one_task():
-    ...
+def test_two_templates_one_task(no_op):
+    tmpl1 = TaskTemplate("tmpl1", no_op)
+    tmpl2 = TaskTemplate("tmpl2", no_op)
+
+    t = tmpl1.task("t1")
+    assert t.name == "t1"
+    assert t.argo_template.name == "tmpl1"
+
+    t = tmpl2.task("t2")
+    assert t.name == "t2"
+    assert t.argo_template.name == "tmpl2"
 
 
-def test_many_templates_many_tasks():
-    ...
+def test_many_templates_many_tasks(op):
+    tmpl1 = TaskTemplate("tmpl1", op, [{"a": 123}])
+    tmpl2 = TaskTemplate("tmpl2", op, [{"a": 456}])
+
+    t1_1, t1_2, t1_3 = tmpl1.task("t1_1"), tmpl1.task("t1_2"), tmpl1.task("t1_3")
+    t2_1, t2_2, t2_3 = tmpl2.task("t2_1"), tmpl2.task("t2_2"), tmpl2.task("t2_3")
+
+    for t1 in [t1_1, t1_2, t1_3]:
+        assert t1.argo_template.name == "tmpl1"
+
+        for p in t1.get_parameters():
+            assert p.name == "a"
+            assert p.value == "123"
+
+    for t2 in [t2_1, t2_2, t2_3]:
+        assert t2.argo_template.name == "tmpl2"
+
+        for p in t2.get_parameters():
+            assert p.name == "a"
+            assert p.value == "456"
 
 
 def test_template_with_multiple_args(op):

--- a/tests/test_task_template.py
+++ b/tests/test_task_template.py
@@ -29,8 +29,7 @@ with open(test_task_file, "r") as file:
 
 
 # Modify all tests to use TaskTemplate. Execution of Task(...) and
-# TaskTemplate(...) should be the same since TaskTemplate inherits from Task and
-# adds another function.
+# TaskTemplate(...) should be the same since TaskTemplate inherits from Task.
 for test_name in _test_func_names:
     _test_func = test_task.__getattribute__(test_name)
     source = inspect.getsource(_test_func)

--- a/tests/test_task_template.py
+++ b/tests/test_task_template.py
@@ -1,5 +1,4 @@
 import inspect
-from os import TMP_MAX
 from pathlib import Path
 
 import test_task

--- a/tests/test_task_template.py
+++ b/tests/test_task_template.py
@@ -5,13 +5,7 @@ import test_task
 
 
 def create_task_from_templated_task(*args, **kwargs):
-    args_str = ', '.join(map(str,args))
-    kwargs_str = ','.join('{}={}'.format(k,v) for k,v in kwargs.items())
-    print(f"{args_str=}")
-    print(f"{kwargs_str=}")
-    # task = TaskTemplate(*args, **kwargs).task(name="asd")
-    task = TaskTemplate(*args, **kwargs).task()
-    return task
+    return TaskTemplate(*args, **kwargs).task()
 
 
 # Get all imports from test_task.py and import here.
@@ -35,9 +29,6 @@ for test_name in _test_func_names:
     modified_lines = lines.replace("Task(", "TaskTemplate(")
     exec(modified_lines)
 
-# ############################# #
-# comment out for testing start #
-# ############################# #
 # Modify all tests to use TaskTemplate(...).task
 for test_name in _test_func_names:
     f = test_task.__getattribute__(test_name)
@@ -53,22 +44,4 @@ for test_name in _test_func_names:
 
     lines = "\n".join(lines)
     lines = lines.replace("Task(", "create_task_from_templated_task(")
-    if test_name == "test_param_getter_parses_single_param_val_on_json_payload":
-        print(lines)
-    try:
-        exec(lines)
-    except Exception:
-        print(lines)
-        break
-    # break
-# ########################### #
-# comment out for testing end #
-# ########################### #
-
-
-# def test_templated_param_getter_parses_single_param_val_on_json_payload(op):
-#     t = create_task_from_templated_task('t', op, [{'a': 1}])
-#     print(t.get_parameters())
-#     param = t.get_parameters()[0]
-#     assert param.name == 'a'
-#     assert param.value == '1'  # from json.dumps
+    exec(lines)

--- a/tests/test_task_template.py
+++ b/tests/test_task_template.py
@@ -144,7 +144,6 @@ def test_add_multiple_tasks_from_one_task_template_to_workflow(w: Workflow, no_o
     tmpl = TaskTemplate(
         "tmpl",
         no_op,
-        resources=Resources(volumes=[Volume(name="test-volume", mount_path="/mnt/test", size="1Mi")]),
     )
     t1, t2, t3 = tmpl.task("t1"), tmpl.task("t2"), tmpl.task("t3")
     w.add_tasks(t1, t2, t3)
@@ -153,3 +152,15 @@ def test_add_multiple_tasks_from_one_task_template_to_workflow(w: Workflow, no_o
     assert (
         len(w.spec.templates) == 2
     ), "Workflow should have 2 templates: one for task template, other for dag template"
+
+
+def test_task_template_with_volume(w: Workflow, no_op):
+    tmpl = TaskTemplate(
+        "tmpl",
+        no_op,
+        resources=Resources(volumes=[Volume(name="test-volume", mount_path="/mnt/test", size="1Mi")]),
+    )
+    t1, t2, t3 = tmpl.task("t1"), tmpl.task("t2"), tmpl.task("t3")
+    w.add_tasks(t1, t2, t3)
+
+    assert id(t1.resources.volumes) == id(t2.resources.volumes) == id(t3.resources.volumes)

--- a/tests/test_task_template.py
+++ b/tests/test_task_template.py
@@ -3,13 +3,26 @@ from test_task import task_security_context_kwargs  # noqa
 import inspect
 import test_task
 
+from pathlib import Path
+
+
+# Get test_task.py path into Path.
+test_task_file = Path(__file__).parent.joinpath("test_task.py")
+
+# Get all test names defined in test_task.py.
+_test_func_names = [test for test in test_task.__dir__() if test.startswith("test")]
+
 
 def create_task_from_templated_task(*args, **kwargs):
+    """
+    Use this function to modify imported tests from test_task.py to use task
+    generated from task template.
+    """
     return TaskTemplate(*args, **kwargs).task()
 
 
 # Get all imports from test_task.py and import here.
-with open("tests/test_task.py", "r") as file:
+with open(test_task_file, "r") as file:
     imports = [
         line
         for line in file.readlines()
@@ -19,32 +32,31 @@ with open("tests/test_task.py", "r") as file:
         exec(i)
 
 
-# Get all test names defined in test_task.py.
-_test_func_names = [test for test in test_task.__dir__() if test.startswith("test")]
-
-# Modify all tests to use TaskTemplate.
+# Modify all tests to use TaskTemplate. Execution of Task(...) and
+# TaskTemplate(...) should be the same since TaskTemplate inherits from Task and
+# adds another function.
 for test_name in _test_func_names:
-    f = test_task.__getattribute__(test_name)
-    lines = inspect.getsource(f)
-    modified_lines = lines.replace("Task(", "TaskTemplate(")
-    exec(modified_lines)
+    test_func = test_task.__getattribute__(test_name)
+    source = inspect.getsource(test_func)
+    modified_source = source.replace("Task(", "TaskTemplate(")
+    exec(modified_source)
 
-# Modify all tests to use TaskTemplate(...).task.
+
+# Modify all tests to use TaskTemplate(...).task. And change test names to avoid
+# duplicates.
 for test_name in _test_func_names:
-    f = test_task.__getattribute__(test_name)
-    lines = inspect.getsource(f)
-    lines = lines.splitlines()
+    test_func = test_task.__getattribute__(test_name)
+    source = inspect.getsource(test_func)
+    lines = source.splitlines()
 
     for index, line in enumerate(lines):
         # Not always first line because of @pytest decorators.
         if line.startswith("def"):
             def_line = line.replace("test_", "test_templated_")
             lines[index] = def_line
-            print(def_line)
 
-    lines = "\n".join(lines)
-    lines = lines.replace("Task(", "create_task_from_templated_task(")
-    exec(lines)
-
-
-# TODO: test task with all possible tasks: python func, bash func, container, daemon, else...?
+    modified_source = "\n".join(lines)
+    modified_source = modified_source.replace(
+        "Task(", f"{create_task_from_templated_task.__name__}("
+    )
+    exec(modified_source)

--- a/tests/test_task_template.py
+++ b/tests/test_task_template.py
@@ -45,3 +45,6 @@ for test_name in _test_func_names:
     lines = "\n".join(lines)
     lines = lines.replace("Task(", "create_task_from_templated_task(")
     exec(lines)
+
+
+# TODO: test task with all possible tasks: python func, bash func, container, daemon, else...?

--- a/tests/test_task_template.py
+++ b/tests/test_task_template.py
@@ -11,14 +11,32 @@ with open("tests/test_task.py", "r") as file:
         if line.startswith("from ") or line.startswith("import ")
     ]
     for i in imports:
-        # print(i)
         exec(i)
 
 
-# Get all tests defined in test_task.py and modify to use TaskTemplate.
+# Get all test names defined in test_task.py.
 _test_func_names = [test for test in test_task.__dir__() if test.startswith("test")]
+
+# Modify all tests to use TaskTemplate.
 for test_name in _test_func_names:
     f = test_task.__getattribute__(test_name)
     lines = inspect.getsource(f)
     modified_lines = lines.replace("Task(", "TaskTemplate(")
     exec(modified_lines)
+
+# Modify all tests to use TaskTemplate(...).task
+for test_name in _test_func_names:
+    f = test_task.__getattribute__(test_name)
+    lines = inspect.getsource(f)
+
+    def_line = next((line for line in lines.splitlines() if line.startswith("def")))
+    def_line = def_line.replace("test_", "test_templated_task_")
+    # print(def_line)
+    lines = lines.splitlines()
+    lines[0] = def_line
+    print(lines)
+    # print(lines)
+    break
+
+    # modified_lines = lines.replace("Task(", "TaskTemplate(")
+    # exec(modified_lines)

--- a/tests/test_task_template.py
+++ b/tests/test_task_template.py
@@ -36,8 +36,8 @@ with open(test_task_file, "r") as file:
 # TaskTemplate(...) should be the same since TaskTemplate inherits from Task and
 # adds another function.
 for test_name in _test_func_names:
-    test_func = test_task.__getattribute__(test_name)
-    source = inspect.getsource(test_func)
+    _test_func = test_task.__getattribute__(test_name)
+    source = inspect.getsource(_test_func)
     modified_source = source.replace("Task(", "TaskTemplate(")
     exec(modified_source)
 
@@ -45,8 +45,8 @@ for test_name in _test_func_names:
 # Modify all tests to use TaskTemplate(...).task. And change test names to avoid
 # duplicates.
 for test_name in _test_func_names:
-    test_func = test_task.__getattribute__(test_name)
-    source = inspect.getsource(test_func)
+    _test_func = test_task.__getattribute__(test_name)
+    source = inspect.getsource(_test_func)
     lines = source.splitlines()
 
     for index, line in enumerate(lines):


### PR DESCRIPTION
## Description

This MR provides additional funcitonality for templating tasks with a class `TaskTemplate`.

## Example
```
task_template = TaskTemplate('myTemplate', say,
    [{
        'message': "default value for param 'message'",
        "other_message": {"default": {"value": {"for": "other_message"}}},
    }],
)
a = task_template.task("taskWithDefaultValues")
b = task_template.task("taskWithNonDefaultValues", [{"other_message": "hello again"}])

```