### PR TITLE
Move pyproject build-system to poetry-core to support editable installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,8 +46,8 @@ isort = "*"
 tox = "<4.0"
 
 [build-system]
-requires = ["poetry"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.black]
 line-length = 119


### PR DESCRIPTION
Update `pyproject.toml`'s `build-system` to point to `poetry-core`. Poetry changed to using a separate (smaller, I think) build backend and suggest changing over to it [in the docs](https://python-poetry.org/docs/pyproject/#poetry-and-pep-517).

This also allows installing the package in editable mode with `pip`:
```sh
$ pip3 install -e /Users/jacobhayes/src/github.com/argoproj-labs/hera-workflows/ # on main
Obtaining file:///Users/jacobhayes/src/github.com/argoproj-labs/hera-workflows
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
ERROR: Project file:///Users/jacobhayes/src/github.com/argoproj-labs/hera-workflows has a 'pyproject.toml' and its build backend is missing the 'build_editable' hook. Since it does not have a 'setup.py' nor a 'setup.cfg', it cannot be installed in editable mode. Consider using a build backend that supports PEP 660.

# switch to this branch

$ pip3 install -e /Users/jacobhayes/src/github.com/argoproj-labs/hera-workflows/ # on update-build-system
Obtaining file:///Users/jacobhayes/src/github.com/argoproj-labs/hera-workflows
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... done
... # rest of the installation
```
