### PR TITLE
Add set_global_token_callback to handle refreshing expiring tokens

### DIFF
--- a/src/hera/__init__.py
+++ b/src/hera/__init__.py
@@ -14,7 +14,12 @@ from hera.cron_workflow_service import CronWorkflowService
 from hera.env import ConfigMapEnvSpec, EnvSpec, FieldEnvSpec, SecretEnvSpec
 from hera.env_from import ConfigMapEnvFromSpec, SecretEnvFromSpec
 from hera.host_alias import HostAlias
-from hera.host_config import set_global_host, set_global_token
+from hera.host_config import (
+    get_global_host,
+    get_global_token,
+    set_global_host,
+    set_global_token,
+)
 from hera.image import ImagePullPolicy
 from hera.input import GlobalInputParameter, Input, InputFrom, InputParameter
 from hera.memoize import Memoize

--- a/src/hera/host_config.py
+++ b/src/hera/host_config.py
@@ -1,25 +1,31 @@
-host = None
-token = None
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Optional, Union
+
+host: Optional[str] = None
+token: Union[Optional[str], Callable[[], Optional[str]]] = None
 
 
-def set_global_host(h):
+def set_global_host(h: Optional[str]) -> None:
     """Sets the Argo Workflows host at a global level so services can use it"""
     global host
     host = h
-    print()
 
 
-def get_global_host():
+def get_global_host() -> Optional[str]:
     """Returns the Argo Workflows global host"""
     return host
 
 
-def set_global_token(t):
+def set_global_token(t: Union[Optional[str], Callable[[], Optional[str]]]) -> None:
     """Sets the Argo Workflows token at a global level so services can use it"""
     global token
     token = t
 
 
-def get_global_token():
-    """Returns the Argo Workflows global token"""
-    return token
+def get_global_token() -> Optional[str]:
+    """Returns an Argo Workflows global token"""
+    if token is None or isinstance(token, str):
+        return token
+    return token()

--- a/tests/test_host_config.py
+++ b/tests/test_host_config.py
@@ -16,10 +16,25 @@ def test_config_fails_when_no_host_is_provided():
     assert str(e.value) == 'A configuration/service host is required for submitting workflows'
 
 
-def test_client_uses_global_token():
+@pytest.mark.parametrize(
+    ["set_token"],
+    [
+        (lambda: set_global_token('token'),),
+        (lambda: set_global_token(lambda: 'token'),),
+    ],
+)
+def test_client_uses_global_token(set_token):
     set_global_host('http://localhost:2746')
-    set_global_token('token')
+    set_token()
     client = Client(Config())
     assert client.api_client.default_headers['Authorization'] == 'Bearer token'
     set_global_token(None)
+    set_global_host(None)
+
+
+def test_config_fails_when_no_token_is_provided():
+    set_global_host('http://localhost:2746')
+    with pytest.raises(AssertionError) as e:
+        Client(Config())
+    assert str(e.value) == 'No token was provided and no global token was found.'
     set_global_host(None)


### PR DESCRIPTION
3.4.0 added support for setting a global token, making it possible to configure credentials once for easier Workflow(Service) instantiation later. :rocket: However, when working with expiring tokens in a long-running service, the caller may need to refresh the token with another call to `set_global_token`. Instead, this PR adds support for passing a callback to `set_global_token` that will be called with no parameters to fetch a token as needed.

The token returned by the callback will not be cached by Hera (we don't know the token's format / how to check for expiry), so callers may want to cache internally if fetching is "expensive".