### PR TITLE
add Reverie Labs to users

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -9,3 +9,4 @@ Please open a PR with your organization or project name in the following section
 
 1. [Dyno Therapeutics](https://www.dynotx.com)
 2. [Pipekit](https://www.pipekit.io)
+3. [ReverieLabs](https://www.reverielabs.com/)

--- a/USERS.md
+++ b/USERS.md
@@ -9,4 +9,4 @@ Please open a PR with your organization or project name in the following section
 
 1. [Dyno Therapeutics](https://www.dynotx.com)
 2. [Pipekit](https://www.pipekit.io)
-3. [ReverieLabs](https://www.reverielabs.com/)
+3. [Reverie Labs](https://www.reverielabs.com/)


### PR DESCRIPTION
@dmerrick I am wondering if you and Reverie Labs are open to listing the organization as users of Hera via `USERS.md`? 🙂 I think it would strengthen Hera's presence in the community and help with adoption!