### PR TITLE
Add arguments for WorkflowTemplates

### DIFF
--- a/examples/workflow_template_global_parameters.py
+++ b/examples/workflow_template_global_parameters.py
@@ -1,0 +1,21 @@
+from hera import (
+    GlobalInputParameter,
+    Task,
+    Variable,
+    WorkflowTemplate,
+    WorkflowTemplateService,
+)
+
+
+def foo(v):
+    print(v)
+
+
+with WorkflowTemplate(
+    "global-parameters",
+    service=WorkflowTemplateService(host="my-argo-server.com", token="my-token"),
+    variables=[Variable("v", "42")],
+) as w:
+    Task("t", foo, inputs=[GlobalInputParameter("v", "v")])
+
+w.create()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hera-workflows"
-version = "3.6.1"
+version = "3.6.2"
 description="Hera is a Python framework for constructing and submitting Argo Workflows. The main goal of Hera is to make Argo Workflows more accessible by abstracting away some setup that is typically necessary for constructing Argo workflows."
 authors = ["Flaviu Vadan <flaviu.vadan@dynotx.com>"]
 license = "MIT"

--- a/src/hera/workflow_template.py
+++ b/src/hera/workflow_template.py
@@ -1,7 +1,8 @@
 """The implementation of a Hera workflowTemplate for Argo-based workflowTemplates"""
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 from argo_workflows.models import (
+    IoArgoprojWorkflowV1alpha1Arguments,
     IoArgoprojWorkflowV1alpha1DAGTemplate,
     IoArgoprojWorkflowV1alpha1Template,
     IoArgoprojWorkflowV1alpha1WorkflowSpec,
@@ -14,6 +15,7 @@ from hera.affinity import Affinity
 from hera.security_context import WorkflowSecurityContext
 from hera.task import Task
 from hera.ttl_strategy import TTLStrategy
+from hera.variable import Variable
 from hera.workflow_editors import add_head, add_tail, add_task, add_tasks, on_exit
 from hera.workflow_template_service import WorkflowTemplateService
 
@@ -51,6 +53,8 @@ class WorkflowTemplate:
         they submit the workflow to.
     affinity: Optional[Affinity] = None
         The task affinity. This dictates the scheduling protocol of the pods running the tasks of the workflow.
+    variables: Optional[List[Variable]] = None
+        A list of global variables for the workflow. These are accessible by all tasks via `GlobalInputParameter`.
     """
 
     def __init__(
@@ -65,6 +69,7 @@ class WorkflowTemplate:
         ttl_strategy: Optional[TTLStrategy] = None,
         node_selectors: Optional[Dict[str, str]] = None,
         affinity: Optional[Affinity] = None,
+        variables: Optional[List[Variable]] = None,
     ):
         self.name = f'{name.replace("_", "-")}'  # RFC1123
         self.namespace = namespace or "default"
@@ -77,6 +82,7 @@ class WorkflowTemplate:
         self.node_selector = node_selectors
         self.affinity = affinity
         self.in_context = False
+        self.variables = variables
 
         self.dag_template = IoArgoprojWorkflowV1alpha1DAGTemplate(tasks=[])
         self.exit_template = IoArgoprojWorkflowV1alpha1Template(
@@ -124,6 +130,15 @@ class WorkflowTemplate:
             setattr(self.dag_template, "node_selector", self.node_selector)
             setattr(self.template, "node_selector", self.node_selector)
             setattr(self.exit_template, "node_selector", self.node_selector)
+
+        if self.variables:
+            setattr(
+                self.spec,
+                "arguments",
+                IoArgoprojWorkflowV1alpha1Arguments(
+                    parameters=[variable.get_argument_parameter() for variable in self.variables],
+                ),
+            )
 
         self.workflow_template = IoArgoprojWorkflowV1alpha1WorkflowTemplate(metadata=self.metadata, spec=self.spec)
 

--- a/tests/test_artifact.py
+++ b/tests/test_artifact.py
@@ -35,7 +35,7 @@ def test_input_artifact_contains_expected_fields():
     assert actual._from == expected._from
     assert actual_input.name == expected.name
     assert actual_input.path == expected.path
-    assert not hasattr(actual_input, '_from')
+    assert not hasattr(actual_input, "_from")
 
 
 def test_git_artifact():

--- a/tests/test_workflow_template.py
+++ b/tests/test_workflow_template.py
@@ -9,6 +9,7 @@ from hera import (
     SecretVolume,
     Task,
     TTLStrategy,
+    Variable,
     Volume,
     WorkflowSecurityContext,
     WorkflowStatus,
@@ -188,3 +189,12 @@ def test_wf_raises_on_create_in_context(wts):
         with pytest.raises(ValueError) as e:
             w.create()
         assert str(e.value) == "Cannot invoke `create` when using a Hera context"
+
+
+def test_wf_sets_variables_as_global_args(wts):
+    with WorkflowTemplate("w", service=wts, variables=[Variable("a", "42")]) as w:
+        assert len(w.variables) == 1
+        assert w.variables[0].name == "a"
+        assert w.variables[0].value == "42"
+        assert hasattr(w.spec, "arguments")
+        assert len(getattr(w.spec, "arguments").parameters) == 1


### PR DESCRIPTION
The spec in WorkflowTemplates is common to Workflows, and has support
for declaring arguments for the template. This change mirrors the usage of Variable
in the Workflow class to declare arguments to the spec.