### PR TITLE
Fix WorkflowService.get_workflow_link when using set_global_host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,13 @@ The general format is:
 
 ```
 
+# 3.6.2 - DATE (29/07/2022)
+
+### Changed
+
+- `Config.host` and `Config.verify_ssl` are now public; `WorkflowService.get_workflow_link` now references `Config.host`
+  to properly pull the host when using `set_global_host`.
+
 # 3.6.1 - DATE (17/07/2022)
 
 ### Removed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hera-workflows"
-version = "3.6.1"
+version = "3.6.2"
 description="Hera is a Python framework for constructing and submitting Argo Workflows. The main goal of Hera is to make Argo Workflows more accessible by abstracting away some setup that is typically necessary for constructing Argo workflows."
 authors = ["Flaviu Vadan <flaviu.vadan@dynotx.com>"]
 license = "MIT"

--- a/src/hera/config.py
+++ b/src/hera/config.py
@@ -28,8 +28,8 @@ class Config:
     """
 
     def __init__(self, host: Optional[str] = None, verify_ssl: bool = True):
-        self._host = host or self._assemble_host()
-        self._verify_ssl = verify_ssl
+        self.host = host or self._assemble_host()
+        self.verify_ssl = verify_ssl
         self._config = self.__get_config()
 
     def _assemble_host(self) -> str:
@@ -80,8 +80,8 @@ class Config:
 
         Use this together with Client to instantiate a WorkflowService/CronWorkflowService.
         """
-        config = ArgoConfig(host=self._host)
-        config.verify_ssl = self._verify_ssl
+        config = ArgoConfig(host=self.host)
+        config.verify_ssl = self.verify_ssl
         return config
 
     @property

--- a/src/hera/cron_workflow_service.py
+++ b/src/hera/cron_workflow_service.py
@@ -41,10 +41,9 @@ class CronWorkflowService:
         token: Optional[str] = None,
         namespace: str = "default",
     ):
-        self._host = host
-        self._verify_ssl = verify_ssl
         self._namespace = namespace
-        api_client = Client(Config(host=self._host, verify_ssl=self._verify_ssl), token=token).api_client
+        self._config = Config(host=host, verify_ssl=verify_ssl)
+        api_client = Client(self._config, token=token).api_client
         self.service = CronWorkflowServiceApi(api_client=api_client)
 
     def create(
@@ -190,7 +189,7 @@ class CronWorkflowService:
         str
             The cron workflow link.
         """
-        return f"{self._host}/cron-workflows/{namespace}/{name}"
+        return f"{self._config.host}/cron-workflows/{namespace}/{name}"
 
     def get_workflow(self, name: str, namespace: str = "default") -> IoArgoprojWorkflowV1alpha1CronWorkflow:
         """Fetches a workflow by the specified name and namespace combination.

--- a/src/hera/workflow_service.py
+++ b/src/hera/workflow_service.py
@@ -40,10 +40,9 @@ class WorkflowService:
         token: Optional[str] = None,
         namespace: str = "default",
     ):
-        self._host = host
-        self._verify_ssl = verify_ssl
         self._namespace = namespace
-        api_client = Client(Config(host=self._host, verify_ssl=self._verify_ssl), token=token).api_client
+        self._config = Config(host=host, verify_ssl=verify_ssl)
+        api_client = Client(self._config, token=token).api_client
         self.service = WorkflowServiceApi(api_client=api_client)
 
     def create(
@@ -104,7 +103,7 @@ class WorkflowService:
         str
             The workflow link.
         """
-        return f"{self._host}/workflows/{self._namespace}/{name}?tab=workflow"
+        return f"{self._config.host}/workflows/{self._namespace}/{name}?tab=workflow"
 
     def get_workflow(self, name: str, namespace: str = "default") -> IoArgoprojWorkflowV1alpha1Workflow:
         """Fetches a workflow by the specified name and namespace combination.

--- a/src/hera/workflow_template_service.py
+++ b/src/hera/workflow_template_service.py
@@ -39,10 +39,9 @@ class WorkflowTemplateService:
         token: Optional[str] = None,
         namespace: str = "default",
     ):
-        self._host = host
-        self._verify_ssl = verify_ssl
         self._namespace = namespace
-        api_client = Client(Config(host=self._host, verify_ssl=self._verify_ssl), token=token).api_client
+        self._config = Config(host=host, verify_ssl=verify_ssl)
+        api_client = Client(self._config, token=token).api_client
         self.service = WorkflowTemplateServiceApi(api_client=api_client)
 
     def create(

--- a/tests/test_cron_workflow_service.py
+++ b/tests/test_cron_workflow_service.py
@@ -17,8 +17,8 @@ from hera import CronWorkflowService
 def test_ws_has_expected_fields_upon_init():
     ws = CronWorkflowService(host="https://abc.com", token="abc", verify_ssl=True, namespace="argo")
 
-    assert ws._host == "https://abc.com"
-    assert ws._verify_ssl
+    assert ws._config.host == "https://abc.com"
+    assert ws._config.verify_ssl
     assert ws._namespace == "argo"
     assert isinstance(ws.service, CronWorkflowServiceApi)
     assert isinstance(ws.service.api_client, ApiClient)

--- a/tests/test_workflow_service.py
+++ b/tests/test_workflow_service.py
@@ -16,8 +16,8 @@ from hera import WorkflowService, WorkflowStatus
 def test_ws_has_expected_fields_upon_init():
     ws = WorkflowService(host="https://abc.com", token="abc", verify_ssl=True, namespace="argo")
 
-    assert ws._host == "https://abc.com"
-    assert ws._verify_ssl
+    assert ws._config.host == "https://abc.com"
+    assert ws._config.verify_ssl
     assert ws._namespace == "argo"
     assert isinstance(ws.service, WorkflowServiceApi)
     assert isinstance(ws.service.api_client, ApiClient)

--- a/tests/test_workflow_template_service.py
+++ b/tests/test_workflow_template_service.py
@@ -15,8 +15,8 @@ from hera import WorkflowTemplateService
 def test_ws_has_expected_fields_upon_init():
     ws = WorkflowTemplateService(host="https://abc.com", token="abc", verify_ssl=True, namespace="argo")
 
-    assert ws._host == "https://abc.com"
-    assert ws._verify_ssl
+    assert ws._config.host == "https://abc.com"
+    assert ws._config.verify_ssl
     assert ws._namespace == "argo"
     assert isinstance(ws.service, WorkflowTemplateServiceApi)
     assert isinstance(ws.service.api_client, ApiClient)


### PR DESCRIPTION
The WorkflowService class was setting `self._host` to the value passed in, but when using `set_global_host`, we often don't pass that parameter. Instead, the instantiated `Config` object calls `get_global_config` to set a fallback for `host=None`, however this wasn't visible to `WorkflowService._host`. Instead of "duplicating" the value across the two classes, I just changed `WorkflowService` to reference the `config` object directly.