### PR TITLE
Resources class does not handle float values properly for min_cpu and max_cpu 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ The general format is:
 
 ```
 
+# 3.6.5 - DATE (22/08/2022)
+
+### Changed
+
+- Fix float type handling for max_cpu and min_cpu properties in Resources class. 
+
 # 3.6.4 - DATE (11/08/2022)
 
 ### Removed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hera-workflows"
-version = "3.6.4"
+version = "3.6.5"
 description="Hera is a Python framework for constructing and submitting Argo Workflows. The main goal of Hera is to make Argo Workflows more accessible by abstracting away some setup that is typically necessary for constructing Argo workflows."
 authors = ["Flaviu Vadan <flaviu.vadan@dynotx.com>"]
 license = "MIT"

--- a/src/hera/resources.py
+++ b/src/hera/resources.py
@@ -12,7 +12,7 @@ class Resources(BaseModel):
 
     Attributes
     ----------
-    min_cpu: Union[int, float] = 1
+    min_cpu: Union[float, int] = 1
         The minimum amount of CPU to request.
     min_mem: str = '4Gi'
         The minimum amount of memory to request.
@@ -20,7 +20,7 @@ class Resources(BaseModel):
         A custom definition of resources, mapped from key to resource specification. Some users have access to custom
         cloud resources, such as "habana.ai/gaudi", which are outside of the knowledge of vanilla K8S, but are provided
         by the K8S engine of the cloud provider. This allows users to take advantage of those.
-    max_cpu: Optional[Union[int, float]] = None
+    max_cpu: Optional[Union[float, int]] = None
         The maximum amount of CPU to request. If this is not specified it's automatically set to min_cpu when
         `overwrite_maxs` is True.
     max_mem: Optional[str]
@@ -42,11 +42,11 @@ class Resources(BaseModel):
         `overwrite_maxs` is False.
     """
 
-    min_cpu: Union[int, float] = 1
+    min_cpu: Union[float, int] = 1
     min_mem: str = "4Gi"
     min_custom_resources: Optional[Dict[str, str]] = None
 
-    max_cpu: Optional[Union[int, float]] = None
+    max_cpu: Optional[Union[float, int]] = None
     max_mem: Optional[str] = None
     max_custom_resources: Optional[Dict[str, str]] = None
 


### PR DESCRIPTION
This tiny pull request aims to solve a small misuse of Pydandic's Union property.

Problem:

When I try to set min_cpu and max_cpu properties to float values, Resources class sliently convert them to integer.

Example code:

```
from hera.task import Resources

resources = Resources(min_cpu=0.5, max_cpu=2.5)
print(resources)
```

Output:
```
min_cpu=0 min_mem='4Gi' min_custom_resources=None max_cpu=2 max_mem='4Gi' max_custom_resources=None gpus=None volumes=None overwrite_maxs=True
```

Notice that min_cpu is 0, not 0.5 and max_cpu is 2 not 2.5


After a quick googling, I found this [ SO page ](https://stackoverflow.com/questions/70399568/pydantic-model-field-of-type-unionint-float-how-to-prevent-field-from-round).


```
x: Union[int, float] = 1 # this usage convert values to intger

y: Union[float, int] = 1 # this usage works as expected

```


Then checked Resources.py and found out that there is the same missuse.

Resources.py (line 45)
```
    min_cpu: Union[int, float] = 1
```

Resources.py (line 49)
```
   max_cpu: Optional[Union[int, float]] = None
```

So, I changed the order of types in Union.