### PR TITLE
Tolerations can now be set via Workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ The general format is:
 
 ```
 
+# 3.7.0 - DATE (26/08/2022)
+
+### Added
+
+- tolerations can now be set via workflow
+
 # 3.6.4 - DATE (11/08/2022)
 
 ### Removed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hera-workflows"
-version = "3.6.4"
+version = "3.7.0"
 description="Hera is a Python framework for constructing and submitting Argo Workflows. The main goal of Hera is to make Argo Workflows more accessible by abstracting away some setup that is typically necessary for constructing Argo workflows."
 authors = ["Flaviu Vadan <flaviu.vadan@dynotx.com>"]
 license = "MIT"

--- a/src/hera/task.py
+++ b/src/hera/task.py
@@ -966,10 +966,8 @@ class Task:
         if self.tolerations is None:
             return []
 
-        ts = []
-        for t in self.tolerations:
-            ts.append(ArgoToleration(key=t.key, effect=t.effect, operator=t.operator, value=t.value))
-        return ts if ts else []
+        ts = [t.to_argo_toleration() for t in self.tolerations]
+        return ts
 
     def get_continue_on(self) -> Optional[IoArgoprojWorkflowV1alpha1ContinueOn]:
         """Assembles and returns the `continue_on` task setting"""

--- a/src/hera/toleration.py
+++ b/src/hera/toleration.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+from argo_workflows.models import Toleration as ArgoToleration
 from pydantic import BaseModel
 
 
@@ -26,6 +27,9 @@ class Toleration(BaseModel):
     effect: str
     operator: str
     value: Optional[str] = ""
+
+    def to_argo_toleration(self):
+        return ArgoToleration(key=self.key, effect=self.effect, operator=self.operator, value=self.value)
 
 
 GPUToleration = Toleration(key="nvidia.com/gpu", effect="NoSchedule", operator="Equal", value="present")

--- a/tests/test_toleration.py
+++ b/tests/test_toleration.py
@@ -1,0 +1,18 @@
+from unittest.mock import Mock
+
+from argo_workflows.models import Toleration as ArgoToleration
+
+from hera import Toleration
+
+
+def test_toleration_translates():
+    hera_t = Toleration(key="a", effect="NoSchedule", operator="Equal", value="value123")
+    argo_t = hera_t.to_argo_toleration()
+    assert hasattr(argo_t, "key")
+    assert hera_t.key == getattr(argo_t, "key")
+    assert hasattr(argo_t, "effect")
+    assert hera_t.effect == getattr(argo_t, "effect")
+    assert hasattr(argo_t, "operator")
+    assert hera_t.operator == getattr(argo_t, "operator")
+    assert hasattr(argo_t, "value")
+    assert hera_t.value == getattr(argo_t, "value")

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -14,6 +14,7 @@ from hera import (
     SecretVolume,
     Task,
     TemplateRef,
+    Toleration,
     TTLStrategy,
     Variable,
     Volume,
@@ -374,3 +375,18 @@ def test_wf_sets_variables_as_global_args(ws):
         assert w.variables[0].value == "42"
         assert hasattr(w.spec, "arguments")
         assert len(getattr(w.spec, "arguments").parameters) == 1
+
+
+def test_wf_sets_tolerations(ws):
+    with Workflow(
+        "w", service=ws, tolerations=[Toleration(key="a", effect="NoSchedule", operator="Exists", value="")]
+    ) as w:
+        assert len(w.tolerations) == 1
+        assert w.tolerations[0].key == "a"
+        assert w.tolerations[0].effect == "NoSchedule"
+        assert w.tolerations[0].operator == "Exists"
+        assert w.tolerations[0].value == ""
+        assert hasattr(w.template, "tolerations")
+        assert len(getattr(w.template, "tolerations")) == 1
+        assert hasattr(w.exit_template, "tolerations")
+        assert len(getattr(w.exit_template, "tolerations")) == 1


### PR DESCRIPTION
Argo supports tolerations being set via the workflow spec, which get propagated to the pods of the workflow.

However, hera, at the moment, doesn't offer the ability to set these tolerations at the workflow level, forcing the caller to set the tolerations at the task level.

The aim of this PR is to add tolerations to the workflow.

I've also taken the opportunity to lightly refactor `hera.Toleration` with a function that converts it to an `argo.Toleration`.