### PR TITLE
Tolerations, nodeSelectors and affinity not being properly set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ The general format is:
 
 ```
 
+# 3.7.1 - DATE (30/08/2022)
+
+### Fixed
+
+- tolerations, node selectors and affinity should be set in the internal workflow spec
+
 # 3.7.0 - DATE (26/08/2022)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ The general format is:
 
 # 3.7.1 - DATE (30/08/2022)
 
+### Added
+
+- tolerations can now be set via cron workflow and workflow spec
+
 ### Fixed
 
 - tolerations, node selectors and affinity should be set in the internal workflow spec

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hera-workflows"
-version = "3.7.0"
+version = "3.7.1"
 description="Hera is a Python framework for constructing and submitting Argo Workflows. The main goal of Hera is to make Argo Workflows more accessible by abstracting away some setup that is typically necessary for constructing Argo workflows."
 authors = ["Flaviu Vadan <flaviu.vadan@dynotx.com>"]
 license = "MIT"

--- a/tests/test_cron_workflow.py
+++ b/tests/test_cron_workflow.py
@@ -27,9 +27,10 @@ from hera import (
     Volume,
     WorkflowStatus,
 )
+from hera.toleration import Toleration
 
 
-def test_wf_contains_specified_service_account(cws, schedule):
+def test_cwf_contains_specified_service_account(cws, schedule):
     w = CronWorkflow("w", schedule, service=cws, service_account_name="w-sa")
 
     expected_sa = "w-sa"
@@ -37,7 +38,7 @@ def test_wf_contains_specified_service_account(cws, schedule):
     assert w.spec.templates[0].service_account_name == expected_sa
 
 
-def test_wf_does_not_contain_sa_if_one_is_not_specified(cws, schedule):
+def test_cwf_does_not_contain_sa_if_one_is_not_specified(cws, schedule):
     w = CronWorkflow("w", schedule, service=cws)
 
     assert not hasattr(w.spec.templates[0], "service_account_name")
@@ -75,7 +76,7 @@ def test_cwf_adds_task_volume(cw, no_op):
     assert claim.metadata.name == "v"
 
 
-def test_wf_adds_task_secret_volume(cw, no_op):
+def test_cwf_adds_task_secret_volume(cw, no_op):
     t = Task("t", no_op, resources=Resources(volumes=[SecretVolume(name="s", secret_name="sn", mount_path="/")]))
     cw.add_task(t)
 
@@ -274,7 +275,7 @@ def test_cwf_adds_image_pull_secrets(ws):
     assert secrets[1] == {"name": "secret1"}
 
 
-def test_wf_adds_ttl_strategy(ws):
+def test_cwf_adds_ttl_strategy(ws):
     w = CronWorkflow(
         "w",
         schedule="* * * * *",
@@ -291,7 +292,7 @@ def test_wf_adds_ttl_strategy(ws):
     assert w.spec.ttl_strategy._data_store == expected_ttl_strategy
 
 
-def test_wf_adds_host_aliases(ws):
+def test_cwf_adds_host_aliases(ws):
     w = CronWorkflow(
         "w",
         schedule="* * * * *",
@@ -306,7 +307,7 @@ def test_wf_adds_host_aliases(ws):
     assert w.spec.host_aliases[1] == ArgoHostAlias(hostnames=["host3"], ip="1.1.1.1")
 
 
-def test_wf_adds_exit_tasks(cw, no_op):
+def test_cwf_adds_exit_tasks(cw, no_op):
     t1 = Task("t1", no_op)
     cw.add_task(t1)
 
@@ -326,7 +327,7 @@ def test_wf_adds_exit_tasks(cw, no_op):
     assert len(cw.spec.templates) == 5
 
 
-def test_wf_catches_tasks_without_exit_status_conditions(cw, no_op):
+def test_cwf_catches_tasks_without_exit_status_conditions(cw, no_op):
     t1 = Task("t1", no_op)
     cw.add_task(t1)
 
@@ -339,34 +340,36 @@ def test_wf_catches_tasks_without_exit_status_conditions(cw, no_op):
     )
 
 
-def test_wf_catches_exit_tasks_without_parent_workflow_tasks(cw, no_op):
+def test_cwf_catches_exit_tasks_without_parent_workflow_tasks(cw, no_op):
     t1 = Task("t1", no_op)
     with pytest.raises(AssertionError) as e:
         cw.on_exit(t1)
     assert str(e.value) == "Cannot add an exit condition to empty workflows"
 
 
-def test_wf_contains_expected_default_exit_template(cw):
+def test_cwf_contains_expected_default_exit_template(cw):
     assert cw.exit_template
     assert cw.exit_template.name == "exit-template"
     assert cw.exit_template.dag.tasks == []
 
 
-def test_wf_contains_expected_node_selectors(cws, schedule):
+def test_cwf_contains_expected_node_selectors(cws, schedule):
     w = CronWorkflow("w", schedule, cws, node_selectors={"foo": "bar"})
+    assert w.spec.node_selector == {"foo": "bar"}
     assert w.template.node_selector == {"foo": "bar"}
     assert w.exit_template.node_selector == {"foo": "bar"}
     assert w.dag_template.node_selector == {"foo": "bar"}
 
 
-def test_wf_adds_affinity(cws, schedule, affinity):
+def test_cwf_adds_affinity(cws, schedule, affinity):
     w = CronWorkflow("w", schedule, cws, affinity=affinity)
     assert w.affinity == affinity
+    assert hasattr(w.spec, "affinity")
     assert hasattr(w.template, "affinity")
     assert hasattr(w.exit_template, "affinity")
 
 
-def test_wf_raises_on_double_context(cws, schedule):
+def test_cwf_raises_on_double_context(cws, schedule):
     with CronWorkflow("w", schedule, service=cws):
         with pytest.raises(ValueError) as e:
             with CronWorkflow("w2", schedule, service=cws):
@@ -374,20 +377,20 @@ def test_wf_raises_on_double_context(cws, schedule):
         assert "Hera context already defined with workflow" in str(e.value)
 
 
-def test_wf_resets_context_indicator(cws, schedule):
+def test_cwf_resets_context_indicator(cws, schedule):
     with CronWorkflow("w", schedule, service=cws) as w:
         assert w.in_context
     assert not w.in_context
 
 
-def test_wf_raises_on_create_in_context(cws, schedule):
+def test_cwf_raises_on_create_in_context(cws, schedule):
     with CronWorkflow("w", schedule, service=cws) as w:
         with pytest.raises(ValueError) as e:
             w.create()
         assert str(e.value) == "Cannot invoke `create` when using a Hera context"
 
 
-def test_wf_sets_variables_as_global_args(cws, schedule):
+def test_cwf_sets_variables_as_global_args(cws, schedule):
     with CronWorkflow("w", schedule, service=cws, variables=[Variable("a", "42")]) as w:
         assert len(w.variables) == 1
         assert w.variables[0].name == "a"
@@ -396,7 +399,24 @@ def test_wf_sets_variables_as_global_args(cws, schedule):
         assert len(getattr(w.spec, "arguments").parameters) == 1
 
 
-def test_wf_adds_volumes(cws, schedule):
+def test_wf_sets_tolerations(cws, schedule):
+    with CronWorkflow(
+        "w", schedule, service=cws, tolerations=[Toleration(key="a", effect="NoSchedule", operator="Exists", value="")]
+    ) as w:
+        assert len(w.tolerations) == 1
+        assert w.tolerations[0].key == "a"
+        assert w.tolerations[0].effect == "NoSchedule"
+        assert w.tolerations[0].operator == "Exists"
+        assert w.tolerations[0].value == ""
+        assert hasattr(w.spec, "tolerations")
+        assert len(getattr(w.spec, "tolerations")) == 1
+        assert hasattr(w.template, "tolerations")
+        assert len(getattr(w.template, "tolerations")) == 1
+        assert hasattr(w.exit_template, "tolerations")
+        assert len(getattr(w.exit_template, "tolerations")) == 1
+
+
+def test_cwf_adds_volumes(cws, schedule):
     with CronWorkflow(
         "w", schedule, service=cws, volumes=[EmptyDirVolume(), Volume(mount_path="/mnt", size="1Gi")]
     ) as w:

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -335,6 +335,7 @@ def test_wf_contains_expected_default_exit_template(w):
 
 def test_wf_contains_expected_node_selectors(ws):
     w = Workflow("w", ws, node_selectors={"foo": "bar"})
+    assert w.spec.node_selector == {"foo": "bar"}
     assert w.template.node_selector == {"foo": "bar"}
     assert w.exit_template.node_selector == {"foo": "bar"}
     assert w.dag_template.node_selector == {"foo": "bar"}
@@ -343,6 +344,7 @@ def test_wf_contains_expected_node_selectors(ws):
 def test_wf_contains_expected_affinity(ws, affinity):
     w = Workflow("w", ws, affinity=affinity)
     assert w.affinity == affinity
+    assert hasattr(w.spec, "affinity")
     assert hasattr(w.template, "affinity")
     assert hasattr(w.exit_template, "affinity")
 
@@ -386,6 +388,8 @@ def test_wf_sets_tolerations(ws):
         assert w.tolerations[0].effect == "NoSchedule"
         assert w.tolerations[0].operator == "Exists"
         assert w.tolerations[0].value == ""
+        assert hasattr(w.spec, "tolerations")
+        assert len(getattr(w.spec, "tolerations")) == 1
         assert hasattr(w.template, "tolerations")
         assert len(getattr(w.template, "tolerations")) == 1
         assert hasattr(w.exit_template, "tolerations")


### PR DESCRIPTION
As I commented on #244, the tolerations, nodeSelectors and affinity are now being properly set in the workflow with the current code:

```python
    workflow = Workflow(
        name="my-wf",
        tolerations=generate_workflow_tolerations(),
        node_selectors=generate_workflow_node_selectors(),
        affinity=generate_workflow_affinity(),
    )
```

results in:

```yaml
spec:
  templates:
  - templates:
    ...
    nodeSelector:
      some_key: value
    tolerations:
    - effect: NoSchedule
      key: some_key
      operator: Exists
    affinity:
      ...
```

These entries in the yaml will be ignored by Argo/k8s and won't have any effect on the workflow, since they are *children* of `templates`.

The solution is to have the entries defined as siblings of `templates`:

```yaml
spec:
  nodeSelector:
    some_key: value
  tolerations:
  - effect: NoSchedule
    key: some_key
    operator: Exists
  affinity:
    ...
  templates:
  - templates:
    ...
```

This matches the API seen in [IoArgoprojWorkflowV1alpha1WorkflowSpec](https://github.com/argoproj/argo-workflows/blob/master/sdks/python/client/argo_workflows/model/io_argoproj_workflow_v1alpha1_workflow_spec.py#L135).

---

Apologies for not spotting this sooner :/