### PR TITLE
add init to tests for pycov for diagnosing CICD config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ whitelist_externals = poetry
 commands =
     poetry install
     poetry run python -m pytest \
-    --cov "src/hera" \
+    --cov "{envsitepackagesdir}/hera-workflows" \
     --cov-config "{toxinidir}/tox.ini"
 
 [testenv:coverage]

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ whitelist_externals = poetry
 commands =
     poetry install
     poetry run python -m pytest \
-    --cov "{envsitepackagesdir}/hera" \
+    --cov "src/hera" \
     --cov-config "{toxinidir}/tox.ini"
 
 [testenv:coverage]

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ whitelist_externals = poetry
 commands =
     poetry install
     poetry run python -m pytest \
-    --cov "{envsitepackagesdir}/hera-workflows" \
+    --cov "src/hera" \
     --cov-config "{toxinidir}/tox.ini"
 
 [testenv:coverage]


### PR DESCRIPTION
No coverage artifacts are generated at the moment. This PR diagnoses that