### PR TITLE
Avoid circular dag_context import

### DIFF
--- a/src/hera/cron_workflow.py
+++ b/src/hera/cron_workflow.py
@@ -24,13 +24,13 @@ class ConcurrencyPolicy(str, Enum):
 
     Replace = "Replace"
     """
-    If it is time for a new job run and the previous job run hasn't finished yet, the cron job replaces the 
+    If it is time for a new job run and the previous job run hasn't finished yet, the cron job replaces the
     currently running job run with a new job run
     """
 
     Forbid = "Forbid"
     """
-    The cron job does not allow concurrent runs; if it is time for a new job run and the previous job run hasn't 
+    The cron job does not allow concurrent runs; if it is time for a new job run and the previous job run hasn't
     finished yet, the cron job skips the new job run.
     """
 

--- a/src/hera/dag.py
+++ b/src/hera/dag.py
@@ -8,7 +8,6 @@ from argo_workflows.models import (
 )
 from argo_workflows.models import Volume as ArgoVolume
 
-from hera._context import dag_context
 from hera.artifact import Artifact
 from hera.io import IO
 from hera.parameter import Parameter

--- a/src/hera/dag.py
+++ b/src/hera/dag.py
@@ -107,14 +107,16 @@ class DAG(IO):
 
     def __enter__(self) -> "DAG":
         """Enter the context of the DAG. This supports the use of `with DAG(...)`"""
-        from hera._context import dag_context
+        from hera import dag_context
+
         self.in_context = True
         dag_context.enter(self)
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
         """Exit the context of the DAG. This supports the use of `with DAG(...)`"""
-        from hera._context import dag_context
+        from hera import dag_context
+
         self.in_context = False
         dag_context.exit()
 

--- a/src/hera/dag.py
+++ b/src/hera/dag.py
@@ -125,7 +125,10 @@ class DAG(IO):
         add_task(self, t)
 
     def add_tasks(self, *ts: Task) -> None:
-        """Add a collection of tasks to the DAG. Note that tasks are added automatically when the DAG context is used"""
+        """Add a collection of tasks to the DAG.
+
+        Note that tasks are added automatically when the DAG context is used
+        """
         add_tasks(self, *ts)
 
     def get_parameter(self, name: str):

--- a/src/hera/env.py
+++ b/src/hera/env.py
@@ -36,8 +36,8 @@ class EnvSpec:
     name: str
         The name of the variable.
     value: Optional[Any] = None
-        The value of the variable. This value is serialized for the client. It is up to the client to deserialize the value
-        in the task. In addition, if another type is passed, covered by `Any`, an attempt at `json.dumps` will be
+        The value of the variable. This value is serialized for the client. It is up to the client to deserialize the
+        value in the task. In addition, if another type is passed, covered by `Any`, an attempt at `json.dumps` will be
         performed.
     value_from_input: Optional[str] = None
         A reference to an input parameter which will resolve to the value. The input parameter will be auto-generated.
@@ -129,8 +129,8 @@ class FieldEnvSpec(EnvSpec, FieldPath):
     name: str
         The name of the variable.
     value: Optional[Any] = None
-        The value of the variable. This value is serialized for the client. It is up to the client to deserialize the value
-        in the task. In addition, if another type is passed, covered by `Any`, an attempt at `json.dumps` will be
+        The value of the variable. This value is serialized for the client. It is up to the client to deserialize the
+        value in the task. In addition, if another type is passed, covered by `Any`, an attempt at `json.dumps` will be
         performed.
     value_from_input: Optional[str] = None
         A reference to an input parameter which will resolve to the value. The input parameter will be auto-generated.

--- a/src/hera/parameter.py
+++ b/src/hera/parameter.py
@@ -52,8 +52,7 @@ class Parameter:
             setattr(parameter, "value_from", IoArgoprojWorkflowV1alpha1ValueFrom(**self.value_from))
         else:
             raise ValueError(
-                f"Parameter with name `{parameter.name}` cannot be interpreted as argument as neither of the following args are set:"
-                " `value`, `value_from`, `default`"
+                f"Parameter with name `{parameter.name}` cannot be interpreted as argument as neither of the following args are set: `value`, `value_from`, `default`"  # noqa
             )
         return parameter
 

--- a/src/hera/retry_policy.py
+++ b/src/hera/retry_policy.py
@@ -23,9 +23,10 @@ class RetryPolicy(str, Enum):
     """Retry steps that encounter Argo controller errors, or whose init or wait containers fail"""
 
     OnTransientError = "OnTransientError"
-    """
-    Retry steps that encounter errors defined as transient, or errors matching the `TRANSIENT_ERROR_PATTERN` 
-    environment variable. Available in version 3.0 and later.
+    """Retry steps that encounter errors defined as transient, or errors matching the `TRANSIENT_ERROR_PATTERN`
+    environment variable.
+
+    Available in version 3.0 and later.
     """
 
     def __str__(self):

--- a/src/hera/validators.py
+++ b/src/hera/validators.py
@@ -1,7 +1,7 @@
 """Holds a collection of validators that are shared in V1"""
 import json
 import re
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
 
 def validate_name(name: str, max_length: Optional[int] = None) -> str:


### PR DESCRIPTION
I think `dag_context` imports were moved into the functions, but the root import was left behind, causing circular imports. This remove that and fixes the imports!
