### PR TITLE
when resource_template is specified on Task, container elem should not be included in output

### DIFF
--- a/src/hera/task.py
+++ b/src/hera/task.py
@@ -819,6 +819,8 @@ class Task(IO):
 
         if self.source is not None:
             setattr(template, "script", self._build_script())
+        elif self.resource_template is not None:
+            setattr(template, "resource", self.resource_template.build())
         else:
             setattr(template, "container", self._build_container())
 
@@ -831,9 +833,6 @@ class Task(IO):
 
         if self.pod_spec_patch is not None:
             setattr(template, "podSpecPatch", self.pod_spec_patch)
-
-        if self.resource_template is not None:
-            setattr(template, "resource", self.resource_template.build())
 
         return template
 

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -710,3 +710,10 @@ def test_task_template_contains_resource_template():
     tt = t._build_template()
     resource = resource_template.build()
     assert tt.resource == resource
+
+
+def test_task_template_with_resource_template_has_no_container():
+    resource_template = ResourceTemplate(action="create")
+    t = Task(name="t", resource_template=resource_template)
+    tt = t._build_template()
+    assert not hasattr(tt, "container")


### PR DESCRIPTION
WF will be rejected if both `container` and `resource` elem are present.

I consider this a quick-fix. A better solution could be to extract a base class from Task. A new ResourceTask could then inherit from that, This will allow the constructor to not include all the params that are specific to  container/source type. That would also allow support for the remaining types
i.e. HTTP : https://argoproj.github.io/argo-workflows/http-template/  and ContainerSets https://argoproj.github.io/argo-workflows/container-set-template/
