### PR TITLE
Split artifacts and parameters

### DIFF
--- a/examples/artifact.py
+++ b/examples/artifact.py
@@ -23,7 +23,7 @@ with Workflow("artifact") as w:
     c_t = Task(
         "consumer",
         consumer,
-        inputs=[w_t.get_output("test")],
+        inputs=[w_t.get_artifact("test")],
     )
 
     w_t >> c_t

--- a/examples/artifact_with_fanout.py
+++ b/examples/artifact_with_fanout.py
@@ -30,7 +30,7 @@ with Workflow("artifact-with-fanout") as w:
     f_t = Task(
         "fanout",
         fanout,
-        inputs=[w_t.get_output("test")],
+        inputs=[w_t.get_artifact("test")],
     )
     c_t = Task("consumer", consumer, with_param=f_t.get_result_as("i"))
     w_t >> f_t >> c_t

--- a/examples/custom_script.py
+++ b/examples/custom_script.py
@@ -1,0 +1,26 @@
+"""This example showcases how to run a custom script rather than a python function in Hera"""
+from hera import Parameter, Task, Workflow
+
+# If the source function of a task has a return type of "str" in its annotation,
+# the task will resolve the function before creation.
+
+
+def script(message: str) -> str:  # <---- '-> str:' here is important!
+    return f"""
+            echo ----------
+            echo {message}
+            echo ----------
+            """
+
+
+# Alternatively, the script can also be a pure string
+# script = """
+#          echo ----------
+#          echo {{inputs.parameters.message}}
+#          echo ----------
+#          """
+
+with Workflow("custom-script") as wf:
+    Task("message", script, command=["sh"], inputs=[Parameter(name="message", value="Magic!")])
+
+wf.create()

--- a/examples/dynamic_fanout_fanin.py
+++ b/examples/dynamic_fanout_fanin.py
@@ -31,7 +31,7 @@ with Workflow("dynamic-fanout-fanin") as w:
         with_param=generate_task.get_result(),
         outputs=[Parameter("value", value_from=dict(path="/tmp/value"))],
     )
-    fanin_task = Task("fanin", fanin, inputs=[fanout_task.get_outputs_as("values")])
+    fanin_task = Task("fanin", fanin, inputs=[fanout_task.get_parameters_as("values")])
 
     generate_task >> fanout_task >> fanin_task
 

--- a/examples/dynamic_fanout_fanin_artifacts.py
+++ b/examples/dynamic_fanout_fanin_artifacts.py
@@ -1,0 +1,64 @@
+# Example derived from: https://medium.com/@corvin/dynamic-fan-out-and-fan-in-in-argo-workflows-d731e144e2fd
+from hera import GCSArtifact, Task, Workflow
+
+
+def generate():
+    import json
+    import os
+    import sys
+
+    files = []
+    # Don't output directly in /tmp/ as it could contain other files
+    output_folder = "/tmp/output-files"
+    os.makedirs(output_folder)
+    for i in range(1, 4):
+        filename = f"file{i}.txt"
+        files.append(filename)
+        with open(os.path.join(output_folder, filename), "w") as f:
+            f.write(f"hello {i}")
+    # Writing a JSON-compliant array of filenames to the output
+    json.dump(files, sys.stdout)
+
+
+def fanout_print():
+    with open("input-file", "r") as f:
+        file_content = f.read()
+    print(f"file content: {file_content}")
+
+
+# assumes you used `hera.set_global_token` and `hera.set_global_host` so that the workflow can be submitted
+with Workflow("artifact-test") as wf:
+    t1 = Task(
+        "generate",
+        generate,
+        outputs=[
+            GCSArtifact(
+                "artifact-files",
+                path="/tmp/output-files/",
+                archive={"none": {}},
+                bucket="<your bucket>",
+                key=f"fanout-{wf.name}",
+            )
+        ],
+    )
+
+    t2 = Task(
+        "fanout-print",
+        fanout_print,
+        with_param=t1.get_result(),
+        inputs=[  # {{item}} refers to each element (file) in t1.get_result()
+            t1.get_artifact("artifact-files").to_path("input-file", sub_path="{{item}}")
+        ],
+    )
+
+    t3 = Task(
+        "fanin",
+        image="alpine:latest",
+        command=["sh", "-c"],
+        args=["ls /tmp/output-files/"],
+        inputs=[t1.get_artifact("artifact-files")],
+    )
+
+    t1 >> t2 >> t3
+
+wf.create()

--- a/examples/input_output.py
+++ b/examples/input_output.py
@@ -13,7 +13,7 @@ def consume(msg: str):
 # assumes you used `hera.set_global_token` and `hera.set_global_host` so that the workflow can be submitted
 with Workflow("io") as w:
     t1 = Task("p", produce, outputs=[Parameter("msg", value_from=dict(path="/test.txt"))])
-    t2 = Task("c", consume, inputs=[t1.get_output("msg")])
+    t2 = Task("c", consume, inputs=[t1.get_parameter("msg")])
     t1 >> t2
 
 w.create()

--- a/examples/memoize.py
+++ b/examples/memoize.py
@@ -13,7 +13,7 @@ def consume(value):
 # assumes you used `hera.set_global_token` and `hera.set_global_host` so that the workflow can be submitted
 with Workflow("memoize") as w:
     g = Task("g", generate, outputs=[Parameter("out", value_from=dict(path="/out"))])
-    c = Task("c", consume, inputs=[g.get_output("out")], memoize=Memoize("value", "memoize", "c"))
+    c = Task("c", consume, inputs=[g.get_parameter("out")], memoize=Memoize("value", "memoize", "c"))
     g >> c
 
 w.create()

--- a/examples/parallel_dag.py
+++ b/examples/parallel_dag.py
@@ -1,0 +1,30 @@
+"""This example showcases how one can schedule a workflow with a parallel DAG task through Hera"""
+from hera import DAG, Parameter, Task, Workflow
+
+
+def produce(instruction: str):
+    instruction_map = {"a": "x", "b": "y", "c": "z"}
+    print(instruction_map[instruction])
+
+
+def wrap(product: str):
+    print(f"({product})")
+
+
+def gather(products: str):
+    print(products)
+
+
+# assumes you used `hera.set_global_token` and `hera.set_global_host` so that the workflow can be submitted
+with Workflow("parallel-dag") as wf:
+    with DAG("pipeline", inputs=[Parameter("instruction")]) as pipeline:
+        t1 = Task("create", produce, inputs=[pipeline.get_parameter("instruction")])
+        t2 = Task("wrap", wrap, inputs=[t1.get_result_as("product")])
+        t1 >> t2
+        pipeline.outputs = [t2.get_result_as("output")]
+
+    t1 = Task("parallel-pipelines", dag=pipeline, with_param=["a", "b", "c"])
+    t2 = Task("gather-results", gather, inputs=[t1.get_parameters_as("products")])
+    t1 >> t2
+
+wf.create()

--- a/src/hera/io.py
+++ b/src/hera/io.py
@@ -56,5 +56,11 @@ class IO:
         Validates that the given function and corresponding params fit one another, raises AssertionError if
         conditions are not satisfied.
         """
-        assert len(set([i.name for i in self.inputs])) == len(self.inputs), "input objects must have unique names"
-        assert len(set([o.name for o in self.outputs])) == len(self.outputs), "output objects must have unique names"
+        i_parameters = [obj.as_input() for obj in self.inputs if isinstance(obj, Parameter)]
+        i_artifacts = [obj.as_input() for obj in self.inputs if isinstance(obj, Artifact)]
+        o_parameters = [obj.as_output() for obj in self.outputs if isinstance(obj, Parameter)]
+        o_artifacts = [obj.as_output() for obj in self.outputs if isinstance(obj, Artifact)]
+        assert len(set([i.name for i in i_parameters])) == len(i_parameters), "input parameters must have unique names"
+        assert len(set([i.name for i in i_artifacts])) == len(i_artifacts), "input artifacts must have unique names"
+        assert len(set([o.name for o in o_parameters])) == len(o_parameters), "input parameters must have unique names"
+        assert len(set([o.name for o in o_artifacts])) == len(o_artifacts), "output objects must have unique names"

--- a/src/hera/parameter.py
+++ b/src/hera/parameter.py
@@ -38,6 +38,11 @@ class Parameter:
         self.default = default
         self.value_from = value_from
 
+    def as_name(self, name: str):
+        """Changes the name of the parameter."""
+        self.name = name
+        return self
+
     def as_argument(self) -> Optional[IoArgoprojWorkflowV1alpha1Parameter]:
         """Assembles the parameter for use as an argument of a task"""
         if self.value is None and self.value_from is None and self.default:

--- a/src/hera/task.py
+++ b/src/hera/task.py
@@ -426,42 +426,53 @@ class Task(IO):
             setattr(arguments, "artifacts", artifacts)
         return arguments
 
-    def get_outputs_as(self, name):
+    def get_parameters_as(self, name):
         """Gets all the output parameters from this task"""
         return Parameter(name=name, value=f"{{{{tasks.{self.name}.outputs.parameters}}}}")
 
-    def get_output(
-        self, name: str, path: Optional[str] = None, as_name: Optional[str] = None
-    ) -> Union[Artifact, Parameter]:
-        """Returns an output object in the form of an artifact or parameter based on the name.
+    def get_parameter(self, name: str) -> Parameter:
+        """Returns a Parameter from this tasks' outputs based on the name.
 
         Parameters
         ----------
         name: str
             The name of the parameter to extract as an output.
-        path: Optional[str] = None
-            Path to the file containing the output to share.
-        as_name: Optional[str] = None
-            Name alias for the parameter. This will be used for sharing the output with the consumer.
-
         Returns
         -------
-        Union[Artifact, Parameter]
-            Artifact or Parameter, depending on whatever shareable object has been identified on the task.
+        Parameter
+            Parameter with the same name
+
         """
-        if as_name is None:
-            as_name = name
-        obj = next((output for output in self.outputs if output.name == name), None)
+        parameters = [p for p in self.outputs if isinstance(p, Parameter)]
+        obj = next((output for output in parameters if output.name == name), None)
         if obj:
             if isinstance(obj, Parameter):
                 value = f"{{{{tasks.{self.name}.outputs.parameters.{name}}}}}"
-                return Parameter(as_name, value, default=obj.default)
-            if isinstance(obj, Artifact):
-                if path is None:  # If a new path isn't set, we use the same as the origin
-                    path = obj.path
-                return Artifact(as_name, path=path, from_task=f"{{{{tasks.{self.name}.outputs.artifacts.{name}}}}}")
+                return Parameter(name, value, default=obj.default)
             raise NotImplementedError(type(obj))
-        raise KeyError(f"No output named {name} found")
+        raise KeyError(f"No output parameter named {name} found")
+
+    def get_artifact(self, name: str) -> Artifact:
+        """Returns an Artifact from this tasks' outputs based on the name.
+
+        Parameters
+        ----------
+        name: str
+            The name of the parameter to extract as an output.
+
+        Returns
+        -------
+        Artifact
+            Artifact with the same name
+
+        """
+        artifacts = [p for p in self.outputs if isinstance(p, Artifact)]
+        obj = next((output for output in artifacts if output.name == name), None)
+        if obj:
+            if isinstance(obj, Artifact):
+                return Artifact(name, path=obj.path, from_task=f"{{{{tasks.{self.name}.outputs.artifacts.{name}}}}}")
+            raise NotImplementedError(type(obj))
+        raise KeyError(f"No output artifact named {name} found")
 
     def get_result(self) -> str:
         """Returns the formatted field that points to the result/output of this task"""

--- a/tests/test_artifact.py
+++ b/tests/test_artifact.py
@@ -14,7 +14,7 @@ def test_output_artifact_contains_expected_fields():
 
     expected = Artifact(name=name, path=path, from_task=f"{{{{tasks.{from_task}.outputs.artifacts.{name}}}}}")
     t1 = Task("produce-artifact", outputs=[Artifact(name, path)])
-    actual = t1.get_output(name)
+    actual = t1.get_artifact(name)
 
     assert isinstance(actual, Artifact)
     assert actual.from_task == expected.from_task
@@ -23,7 +23,7 @@ def test_output_artifact_contains_expected_fields():
 
     new_path = "/input/alternative_path"
     expected = Artifact(name=name, path=new_path, from_task=f"{{{{tasks.{from_task}.outputs.artifacts.{name}}}}}")
-    actual = t1.get_output(name, new_path)
+    actual = t1.get_artifact(name).to_path(new_path)
     assert isinstance(actual, Artifact)
     assert actual.from_task == expected.from_task
     assert actual.name == expected.name
@@ -31,7 +31,7 @@ def test_output_artifact_contains_expected_fields():
 
     new_name = "test-artifact2"
     expected = Artifact(name=new_name, path=new_path, from_task=f"{{{{tasks.{from_task}.outputs.artifacts.{name}}}}}")
-    actual = t1.get_output(name, new_path, as_name=new_name)
+    actual = t1.get_artifact(name).to_path(new_path).as_name(new_name)
     assert isinstance(actual, Artifact)
     assert actual.from_task == expected.from_task
     assert actual.name == expected.name

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -355,12 +355,12 @@ def test_task_sets_kwarg(kwarg_op, kwarg_multi_op):
 
     t = Task("t", kwarg_multi_op, [{"a": 50}])
     generated_input_1 = t.inputs[0]
-    assert isinstance(generated_input, Parameter)
+    assert isinstance(generated_input_1, Parameter)
     assert generated_input_1.name == "a"
     assert generated_input_1.value == "{{item.a}}"
 
     generated_input_2 = t.inputs[1]
-    assert isinstance(generated_input, Parameter)
+    assert isinstance(generated_input_2, Parameter)
     assert generated_input_2.name == "b"
     assert generated_input_2.value == "43"
 
@@ -368,7 +368,7 @@ def test_task_sets_kwarg(kwarg_op, kwarg_multi_op):
 def test_task_fails_artifact_validation(no_op, artifact):
     with pytest.raises(AssertionError) as e:
         Task("t", no_op, inputs=[artifact, artifact])
-    assert str(e.value) == "input objects must have unique names"
+    assert str(e.value) == "input artifacts must have unique names"
 
 
 def test_task_artifact_returns_expected_list(no_op, artifact):


### PR DESCRIPTION
* Split `get_output` into `get_artifact` and `get_parameter` for `Task`
* Refactor `get_outputs_as` to `get_parameters_as` (this never applied for artifacts)
* `as_name` argument in `get_output` moved as a separate method for both artifact and parameter. E.g: `get_parameter("param").as_name("value")`
* Bucket artifacts has `archive` argument
* Add new examples
