### PR TITLE
Return argo result on submission

### DIFF
--- a/src/hera/cron_workflow.py
+++ b/src/hera/cron_workflow.py
@@ -100,18 +100,17 @@ class CronWorkflow(Workflow):
             spec=cron_workflow_spec,
         )
 
-    def create(self) -> "CronWorkflow":
+    def create(self) -> IoArgoprojWorkflowV1alpha1CronWorkflow:
         """Creates the cron workflow"""
         if self.in_context:
             raise ValueError("Cannot invoke `create` when using a Hera context")
-        self.service.create_cron_workflow(self.build())
-        return self
+        return self.service.create_cron_workflow(self.build())
 
     def delete(self) -> Tuple[object, int, dict]:
         """Deletes the cron workflow"""
         return self.service.delete_cron_workflow(self.name)
 
-    def update(self) -> "CronWorkflow":
+    def update(self) -> IoArgoprojWorkflowV1alpha1CronWorkflow:
         """Updates the cron workflow in the server"""
 
         # when update cron_workflow, metadata.resourceVersion and metadata.uid should be same as the previous value
@@ -119,8 +118,7 @@ class CronWorkflow(Workflow):
         cron_workflow = self.build()
         cron_workflow.metadata["resourceVersion"] = old_workflow.metadata["resourceVersion"]
         cron_workflow.metadata["uid"] = old_workflow.metadata["uid"]
-        self.service.update_cron_workflow(self.name, cron_workflow)
-        return self
+        return self.service.update_cron_workflow(self.name, cron_workflow)
 
     def suspend(self) -> Tuple[object, int, dict]:
         """Suspends the cron workflow"""

--- a/src/hera/workflow.py
+++ b/src/hera/workflow.py
@@ -258,14 +258,13 @@ class Workflow:
         add_tasks(self, *ts)
         return self
 
-    def create(self) -> "Workflow":
+    def create(self) -> IoArgoprojWorkflowV1alpha1Workflow:
         """Creates the workflow"""
         assert self.dag
         if self.in_context:
             raise ValueError("Cannot invoke `create` when using a Hera context")
 
-        self.service.create_workflow(self.build())
-        return self
+        return self.service.create_workflow(self.build())
 
     def on_exit(self, other: Union[Task, DAG]) -> None:
         """Add a task or a DAG to execute upon workflow exit"""

--- a/src/hera/workflow_template.py
+++ b/src/hera/workflow_template.py
@@ -21,18 +21,16 @@ class WorkflowTemplate(Workflow):
         spec = super()._build_spec(workflow_template=True)
         return IoArgoprojWorkflowV1alpha1WorkflowTemplate(metadata=self._build_metadata(), spec=spec)
 
-    def create(self) -> "WorkflowTemplate":
+    def create(self) -> IoArgoprojWorkflowV1alpha1WorkflowTemplate:
         """Creates a workflow template"""
         if self.in_context:
             raise ValueError("Cannot invoke `create` when using a Hera context")
         assert self.dag is not None
-        self.service.create_workflow_template(self.build())
-        return self
+        return self.service.create_workflow_template(self.build())
 
-    def update(self) -> "WorkflowTemplate":
+    def update(self) -> Tuple[object, int, dict]:
         """Updates an existing workflow template"""
-        self.service.update_workflow_template(self.name, self.build())
-        return self
+        return self.service.update_workflow_template(self.name, self.build())
 
     def delete(self) -> Tuple[object, int, dict]:
         """Deletes the workflow"""


### PR DESCRIPTION
If we're using concepts like `generate_name`, we won't know the final name of the workflow until we submit it. The user might want to fetch this via the returned object upon creation, which holds this information. Typically: `result.metadata['name']`