### PR TITLE
Adjust README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,31 +21,25 @@ and its crew were specially protected by the goddess Hera.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-Hera is a Python framework for constructing and submitting Argo Workflows. The main goal of Hera is to make Argo
-Workflows more accessible by abstracting away some setup that is typically necessary for constructing workflows.
-
-Python functions are first class citizens in Hera - they are the atomic units (execution payload) that are submitted for
-remote execution. The framework makes it easy to wrap execution payloads into Argo Workflow tasks, set dependencies,
-resources, etc.
+Hera is a Python framework for constructing and submitting Argo Workflows. The main goal of Hera is to make the Argo
+ecosystem accessible by simplifying workflow construction and submission.
 
 You can watch the introductory Hera presentation at the "Argo Workflows and Events Community Meeting 20 Oct
 2021" [here](https://www.youtube.com/watch?v=QETfzfVV-GY&t=181s)!
 
 # Table of content
 
-- [Assumptions](#assumptions)
 - [Installation](#installation)
 - [Examples](#examples)
+- [Requirements](#requirements)
 - [Contributing](#contributing)
-- [Concepts](#concepts)
 - [Comparison](#comparison)
 
-# Assumptions
+# Requirements
 
-Hera is exclusively dedicated to remote workflow submission and execution. Therefore, it requires an Argo server to be
-deployed to a Kubernetes cluster. Currently, Hera assumes that the Argo server sits behind an authentication layer that
-can authenticate workflow submission requests by using the Bearer token on the request. To learn how to deploy Argo to
-your own Kubernetes cluster you can follow the
+Hera requires an Argo server to be deployed to a Kubernetes cluster. Currently, Hera assumes that the Argo server sits
+behind an authentication layer that can authenticate workflow submission requests by using the Bearer token on the
+request. To learn how to deploy Argo to your own Kubernetes cluster you can follow the
 [Argo Workflows](https://argoproj.github.io/argo-workflows/quick-start/) guide!
 
 Another option for workflow submission without the authentication layer is using port forwarding to your Argo server
@@ -53,52 +47,31 @@ deployment and submitting workflows to `localhost:2746` (2746 is the default, bu
 refer to the documentation of [Argo Workflows](https://argoproj.github.io/argo-workflows/quick-start/) to see the
 command for port forward!
 
-In the future some of these assumptions may either increase or decrease depending on the direction of the project. Hera
-is mostly designed for practical data science purposes, which assumes the presence of a DevOps team to set up an Argo
-server for workflow submission.
-
 # Installation
 
-There are multiple ways to install Hera:
-
-1. You can install from [PyPi](https://pypi.org/project/hera-workflows/):
-
-   ```shell
-   pip install hera-workflows
-   ```
-
-2. You can install from [conda](https://anaconda.org/conda-forge/hera-workflows):
-
-   ```shell
-   conda install -c conda-forge hera-workflows
-   ```
-
-3. Install it directly from this repository using:
-
-   ```shell
-   python -m pip install git+https://github.com/argoproj-labs/hera-workflows --ignore-installed
-   ```
-
-4. Alternatively, you can clone this repository and then run the following to install:
-
-   ```shell
-   pip install .
-   ```
+| Source                                                         | Command                                                                                                        |
+|----------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------|
+| [PyPi](https://pypi.org/project/hera-workflows/)               | `pip install hera-workflows`                                                                                   |
+| [Conda](https://anaconda.org/conda-forge/hera-workflows)       | `conda install -c conda-forge hera-workflows`                                                                  |
+| [GitHub repo](https://github.com/argoproj-labs/hera-workflows) | `python -m pip install git+https://github.com/argoproj-labs/hera-workflows --ignore-installed`/`pip install .` |
 
 # Examples
-
-A very primitive example of submitting a task within a workflow through Hera is:
 
 ```python
 from hera import Task, Workflow
 
 
-def say(m: str):
-    print(m)
+def say(message: str):
+    print(message)
 
 
-with Workflow('my-workflow') as w:
-    Task('say', say, ['Hello, world!'])
+with Workflow("diamond") as w:
+    a = Task('a', say, ['This is task A!'])
+    b = Task('b', say, ['This is task B!'])
+    c = Task('c', say, ['This is task C!'])
+    d = Task('d', say, ['This is task D!'])
+
+    a >> [b, c] >> d
 
 w.create()
 ```
@@ -139,14 +112,6 @@ As `coverage` *depends* on `py37`, it will run *after* `py37`
 See project `tox.ini` for more details
 
 Also, see the [contributing guide](https://github.com/argoproj-labs/hera-workflows/blob/main/CONTRIBUTING.md)!
-
-# Concepts
-
-Currently, Hera is centered around two core concepts. These concepts are also used by Argo, which Hera aims to stay
-consistent with:
-
-- `Task` - the object that holds the Python function for remote execution/the atomic unit of execution;
-- `Workflow` - the higher level representation of a collection of tasks.
 
 # Comparison
 


### PR DESCRIPTION
@Trollgeir we discussed removing the `Comparison` section. However, I kept it here because I noticed that _most_ open-source projects on GitHub (from the ones I viewed) do not provide a comparison. Providing a comparison helps users understand advantages/disadvantages of their SDK choice, Argo SDK in this case. Thoughts?