### PR TITLE
Add custom `Archive` and `Backoff` object

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.black]
 line-length = 119
+skip-string-normalization = true
 target-version = ['py37']
 include = '\.pyi?$'
 
@@ -63,6 +64,7 @@ max-line-length = 119
 addopts = "-ra -q"
 
 [tool.isort]
+known_first_party = ["hera"]
 profile = "black"
 skip_gitignore = true
 skip_glob = [".venv/*", ".mypy_cache/*", ".pytest_cache/*", ".github/*", ".git/*"]

--- a/src/hera/__init__.py
+++ b/src/hera/__init__.py
@@ -40,6 +40,7 @@ from hera.parameter import Parameter
 from hera.resource_template import ResourceTemplate
 from hera.resources import Resources
 from hera.retry_policy import RetryPolicy
+from hera.archive import Archive
 from hera.retry_strategy import RetryStrategy
 from hera.security_context import TaskSecurityContext, WorkflowSecurityContext
 from hera.sequence import Sequence

--- a/src/hera/__init__.py
+++ b/src/hera/__init__.py
@@ -17,6 +17,7 @@ from hera.affinity import (
     PreferredSchedulingTerm,
     WeightedPodAffinityTerm,
 )
+from hera.archive import Archive
 from hera.artifact import Artifact, GCSArtifact, GitArtifact, HttpArtifact, S3Artifact
 from hera.client import Client
 from hera.config import Config
@@ -40,7 +41,6 @@ from hera.parameter import Parameter
 from hera.resource_template import ResourceTemplate
 from hera.resources import Resources
 from hera.retry_policy import RetryPolicy
-from hera.archive import Archive
 from hera.retry_strategy import RetryStrategy
 from hera.security_context import TaskSecurityContext, WorkflowSecurityContext
 from hera.sequence import Sequence

--- a/src/hera/__init__.py
+++ b/src/hera/__init__.py
@@ -19,6 +19,7 @@ from hera.affinity import (
 )
 from hera.archive import Archive
 from hera.artifact import Artifact, GCSArtifact, GitArtifact, HttpArtifact, S3Artifact
+from hera.backoff import Backoff
 from hera.client import Client
 from hera.config import Config
 from hera.cron_workflow import ConcurrencyPolicy, CronWorkflow

--- a/src/hera/archive.py
+++ b/src/hera/archive.py
@@ -1,0 +1,35 @@
+from dataclasses import dataclass
+from typing import Optional
+from argo_workflows.models import IoArgoprojWorkflowV1alpha1ArchiveStrategy, IoArgoprojWorkflowV1alpha1TarStrategy
+
+
+@dataclass
+class Archive:
+    """Archive sets the archival behavior of artifacts.
+
+    Attributes
+    ----------
+    disable_compression: Optional[bool] = None
+        Whether to disable compression intentionally.
+    tar_compression_level: Optional[int]
+        Specifies the gzip compression level to use for an artifact. The default is the gzip `flate.DefaultCompression`
+        which is set to -1.
+    zip: Optional[bool] = None
+        Whether to unzip zipped input artifacts.
+    """
+
+    disable_compression: Optional[bool] = None
+    tar_compression_level: Optional[int] = None
+    zip: Optional[bool] = None
+
+    def build(self) -> IoArgoprojWorkflowV1alpha1ArchiveStrategy:
+        strategy = IoArgoprojWorkflowV1alpha1ArchiveStrategy()
+        if self.disable_compression is not None and self.disable_compression:
+            # this needs to be set only in the `True` case as `False` is also interpreted as `disable archiving`
+            setattr(strategy, '_none', self.disable_compression)
+        if self.tar_compression_level is not None:
+            setattr(strategy, 'tar', IoArgoprojWorkflowV1alpha1TarStrategy(compression_level=self.tar_compression_level))
+        if self.zip is not None and self.zip:
+            # this needs to be set only in the `True` case as `False` is also interpreted as `disable archiving`
+            setattr(strategy, 'zip', self.zip)
+        return strategy

--- a/src/hera/archive.py
+++ b/src/hera/archive.py
@@ -1,6 +1,10 @@
 from dataclasses import dataclass
 from typing import Optional
-from argo_workflows.models import IoArgoprojWorkflowV1alpha1ArchiveStrategy, IoArgoprojWorkflowV1alpha1TarStrategy
+
+from argo_workflows.models import (
+    IoArgoprojWorkflowV1alpha1ArchiveStrategy,
+    IoArgoprojWorkflowV1alpha1TarStrategy,
+)
 
 
 @dataclass
@@ -26,10 +30,12 @@ class Archive:
         strategy = IoArgoprojWorkflowV1alpha1ArchiveStrategy()
         if self.disable_compression is not None and self.disable_compression:
             # this needs to be set only in the `True` case as `False` is also interpreted as `disable archiving`
-            setattr(strategy, '_none', self.disable_compression)
+            setattr(strategy, "_none", self.disable_compression)
         if self.tar_compression_level is not None:
-            setattr(strategy, 'tar', IoArgoprojWorkflowV1alpha1TarStrategy(compression_level=self.tar_compression_level))
+            setattr(
+                strategy, "tar", IoArgoprojWorkflowV1alpha1TarStrategy(compression_level=self.tar_compression_level)
+            )
         if self.zip is not None and self.zip:
             # this needs to be set only in the `True` case as `False` is also interpreted as `disable archiving`
-            setattr(strategy, 'zip', self.zip)
+            setattr(strategy, "zip", self.zip)
         return strategy

--- a/src/hera/artifact.py
+++ b/src/hera/artifact.py
@@ -85,7 +85,6 @@ class BucketArtifact(Artifact):
     Don't use this directly. Use S3InputArtifact or GCSInputArtifact.
     """
 
-    # TODO: make custom object for Archive
     def __init__(self, name: str, path: str, bucket: str, key: str, archive: Optional[Archive] = None) -> None:
         self.bucket = bucket
         self.key = key

--- a/src/hera/artifact.py
+++ b/src/hera/artifact.py
@@ -1,7 +1,6 @@
-from typing import Dict, List, Optional
+from typing import List, Optional
 
 from argo_workflows.models import (
-    IoArgoprojWorkflowV1alpha1ArchiveStrategy,
     IoArgoprojWorkflowV1alpha1Artifact,
     IoArgoprojWorkflowV1alpha1GCSArtifact,
     IoArgoprojWorkflowV1alpha1GitArtifact,
@@ -9,6 +8,8 @@ from argo_workflows.models import (
     IoArgoprojWorkflowV1alpha1S3Artifact,
     SecretKeySelector,
 )
+
+from hera.archive import Archive
 
 
 class Artifact:
@@ -85,7 +86,7 @@ class BucketArtifact(Artifact):
     """
 
     # TODO: make custom object for Archive
-    def __init__(self, name: str, path: str, bucket: str, key: str, archive: Optional[Dict] = None) -> None:
+    def __init__(self, name: str, path: str, bucket: str, key: str, archive: Optional[Archive] = None) -> None:
         self.bucket = bucket
         self.key = key
         self.archive = archive
@@ -102,8 +103,8 @@ class S3Artifact(BucketArtifact):
             path=self.path,
             s3=IoArgoprojWorkflowV1alpha1S3Artifact(bucket=self.bucket, key=self.key),
         )
-        if self.archive:
-            setattr(artifact, "archive", IoArgoprojWorkflowV1alpha1ArchiveStrategy(**self.archive))
+        if self.archive is not None:
+            setattr(artifact, "archive", self.archive.build())
         return artifact
 
     def as_input(self) -> IoArgoprojWorkflowV1alpha1Artifact:
@@ -125,8 +126,8 @@ class GCSArtifact(BucketArtifact):
             path=self.path,
             gcs=IoArgoprojWorkflowV1alpha1GCSArtifact(bucket=self.bucket, key=self.key),
         )
-        if self.archive:
-            setattr(artifact, "archive", IoArgoprojWorkflowV1alpha1ArchiveStrategy(**self.archive))
+        if self.archive is not None:
+            setattr(artifact, "archive", self.archive.build())
         return artifact
 
     def as_input(self) -> IoArgoprojWorkflowV1alpha1Artifact:

--- a/src/hera/backoff.py
+++ b/src/hera/backoff.py
@@ -1,0 +1,41 @@
+from dataclasses import dataclass
+from typing import Optional, Union
+
+from argo_workflows.models import IoArgoprojWorkflowV1alpha1Backoff
+
+
+@dataclass
+class Backoff:
+    """The backoff strategy to use with a retry strategy.
+
+    Attributes
+    ----------
+    duration: Optional[str] = None
+        Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h").
+    factor: Optional[Union[int, str]] = None
+        Factor is a factor to multiply the base duration by after each failed retry.
+    max_duration: Optional[str] = None
+        MaxDuration is the maximum amount of time allowed for the backoff strategy.
+
+    See Also
+    --------
+    https://argoproj.github.io/argo-workflows/fields/#backoff
+    """
+
+    duration: Optional[str] = None
+    factor: Optional[Union[int, str]] = None
+    max_duration: Optional[str] = None
+
+    def __post_init__(self):
+        if self.factor is not None and isinstance(self.factor, int):
+            self.factor = str(self.factor)
+
+    def build(self) -> IoArgoprojWorkflowV1alpha1Backoff:
+        backoff = IoArgoprojWorkflowV1alpha1Backoff()
+        if self.duration is not None:
+            setattr(backoff, "duration", self.duration)
+        if self.factor is not None:
+            setattr(backoff, "factor", self.factor)
+        if self.max_duration is not None:
+            setattr(backoff, "max_duration", self.max_duration)
+        return backoff

--- a/src/hera/parameter.py
+++ b/src/hera/parameter.py
@@ -74,9 +74,7 @@ class Parameter:
     def as_output(self) -> IoArgoprojWorkflowV1alpha1Parameter:
         """Assembles the parameter for use as an output of a task"""
         if self.value_from:
-            return IoArgoprojWorkflowV1alpha1Parameter(
-                name=self.name, value_from=self.value_from.build()
-            )
+            return IoArgoprojWorkflowV1alpha1Parameter(name=self.name, value_from=self.value_from.build())
         else:
             argo_value_from = IoArgoprojWorkflowV1alpha1ValueFrom(parameter=self.value)
             if self.default:

--- a/src/hera/retry_strategy.py
+++ b/src/hera/retry_strategy.py
@@ -43,7 +43,7 @@ class RetryStrategy:
         if self.affinity is not None:
             setattr(strategy, "affinity", IoArgoprojWorkflowV1alpha1RetryAffinity(**self.affinity))
         if self.backoff is not None:
-            setattr(strategy, "backoff", IoArgoprojWorkflowV1alpha1Backoff(**self.backoff))
+            setattr(strategy, "backoff", self.backoff.build())
         if self.expression is not None:
             setattr(strategy, "expression", self.expression)
         if self.limit is not None:

--- a/src/hera/retry_strategy.py
+++ b/src/hera/retry_strategy.py
@@ -7,6 +7,7 @@ from argo_workflows.models import (
     IoArgoprojWorkflowV1alpha1RetryStrategy,
 )
 
+from hera.backoff import Backoff
 from hera.retry_policy import RetryPolicy
 
 
@@ -19,9 +20,8 @@ class RetryStrategy:
     affinity: Optional[Dict] = None
         Affinity prevents running workflow's step on the same host.
         See: https://argoproj.github.io/argo-workflows/fields/#retryaffinity
-    backoff: Optional[Dict] = None
-        Backoff strategy.
-        See: https://argoproj.github.io/argo-workflows/fields/#backoff
+    backoff: Optional[Backoff] = None
+        Backoff strategy. See `hera.backoff.Backoff` or https://argoproj.github.io/argo-workflows/fields/#backoff.
     expression: Optional[str] = None
         Expression is a condition expression for when a node will be retried.
         If it evaluates to false, the node will not be retried and the retry strategy will be ignored
@@ -33,7 +33,7 @@ class RetryStrategy:
 
     # TODO: make custom object for Backoff, Affinity
     affinity: Optional[Dict] = None
-    backoff: Optional[Dict] = None
+    backoff: Optional[Backoff] = None
     expression: Optional[str] = None
     limit: Optional[int] = None
     retry_policy: RetryPolicy = RetryPolicy.Always

--- a/src/hera/retry_strategy.py
+++ b/src/hera/retry_strategy.py
@@ -17,9 +17,6 @@ class RetryStrategy:
 
     Attributes
     ----------
-    affinity: Optional[Dict] = None
-        Affinity prevents running workflow's step on the same host.
-        See: https://argoproj.github.io/argo-workflows/fields/#retryaffinity
     backoff: Optional[Backoff] = None
         Backoff strategy. See `hera.backoff.Backoff` or https://argoproj.github.io/argo-workflows/fields/#backoff.
     expression: Optional[str] = None
@@ -31,8 +28,6 @@ class RetryStrategy:
         The strategy for performing retries, for example OnError vs OnFailure vs Always
     """
 
-    # TODO: make custom object for Backoff, Affinity
-    affinity: Optional[Dict] = None
     backoff: Optional[Backoff] = None
     expression: Optional[str] = None
     limit: Optional[int] = None
@@ -40,8 +35,6 @@ class RetryStrategy:
 
     def build(self):
         strategy = IoArgoprojWorkflowV1alpha1RetryStrategy()
-        if self.affinity is not None:
-            setattr(strategy, "affinity", IoArgoprojWorkflowV1alpha1RetryAffinity(**self.affinity))
         if self.backoff is not None:
             setattr(strategy, "backoff", self.backoff.build())
         if self.expression is not None:

--- a/src/hera/retry_strategy.py
+++ b/src/hera/retry_strategy.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Union
 
 from argo_workflows.models import IoArgoprojWorkflowV1alpha1RetryStrategy
 
@@ -18,25 +18,29 @@ class RetryStrategy:
     expression: Optional[str] = None
         Expression is a condition expression for when a node will be retried.
         If it evaluates to false, the node will not be retried and the retry strategy will be ignored
-    limit: Optional[int] = None
-        The number of retries to attempt
+    limit: Optional[Union[int, str]] = None
+        The number of retries to attempt.
     retry_policy: RetryPolicy
         The strategy for performing retries, for example OnError vs OnFailure vs Always
     """
 
     backoff: Optional[Backoff] = None
     expression: Optional[str] = None
-    limit: Optional[int] = None
+    limit: Optional[Union[int, str]] = None
     retry_policy: RetryPolicy = RetryPolicy.Always
 
-    def build(self):
+    def __post_init__(self):
+        if self.limit is not None and isinstance(self.limit, int):
+            self.limit = str(self.limit)
+
+    def build(self) -> IoArgoprojWorkflowV1alpha1RetryStrategy:
         strategy = IoArgoprojWorkflowV1alpha1RetryStrategy()
         if self.backoff is not None:
             setattr(strategy, "backoff", self.backoff.build())
         if self.expression is not None:
             setattr(strategy, "expression", self.expression)
         if self.limit is not None:
-            setattr(strategy, "limit", str(self.limit))
+            setattr(strategy, "limit", self.limit)
         if self.retry_policy is not None:
             setattr(strategy, "retry_policy", str(self.retry_policy.value))
 

--- a/src/hera/retry_strategy.py
+++ b/src/hera/retry_strategy.py
@@ -1,11 +1,7 @@
 from dataclasses import dataclass
-from typing import Dict, Optional
+from typing import Optional
 
-from argo_workflows.models import (
-    IoArgoprojWorkflowV1alpha1Backoff,
-    IoArgoprojWorkflowV1alpha1RetryAffinity,
-    IoArgoprojWorkflowV1alpha1RetryStrategy,
-)
+from argo_workflows.models import IoArgoprojWorkflowV1alpha1RetryStrategy
 
 from hera.backoff import Backoff
 from hera.retry_policy import RetryPolicy

--- a/src/hera/security_context.py
+++ b/src/hera/security_context.py
@@ -25,7 +25,7 @@ class BaseSecurityContext:
     run_as_group: Optional[int] = None
     run_as_non_root: Optional[bool] = None
 
-    def _get_settable_attributes_as_kwargs(self):
+    def _get_settable_attributes_as_kwargs(self) -> dict:
         """Assembles non-None attribute mappings, from key to value"""
         attributes = asdict(self)
         settable_attributes = {k: v for k, v in attributes.items() if v is not None}
@@ -34,7 +34,7 @@ class BaseSecurityContext:
 
 @dataclass
 class WorkflowSecurityContext(BaseSecurityContext):
-    """Defines workflow level sercurity attributes and settings.
+    """Defines workflow level security attributes and settings.
 
     Attributes
     ----------
@@ -45,9 +45,9 @@ class WorkflowSecurityContext(BaseSecurityContext):
     run_as_group: Optional[int]
         Sets the user id of the user running in all the containers in the workflow.
     fs_group: Optional[int]
-        Allow an additional group to the all users running on all of the containers in the workflow.
+        Allow an additional group to all the users running on the containers in the workflow.
     run_as_non_root: Optional[bool]
-        Validates that all the tasks' container does not run as root, i.e UID does not equal 0.
+        Validates that all the tasks' container does not run as root, i.e, UID does not equal 0.
     """
 
     fs_group: Optional[int] = None
@@ -79,12 +79,12 @@ class TaskSecurityContext(BaseSecurityContext):
 
     additional_capabilities: List[str] = field(default_factory=list)
 
-    def _get_capabilties(self):
+    def _get_capabilties(self) -> Capabilities:
         """Assembles the capabilities of the task security context"""
         if self.additional_capabilities:
             return Capabilities(add=self.additional_capabilities)
 
-    def _get_settable_attributes_as_kwargs(self):
+    def _get_settable_attributes_as_kwargs(self) -> dict:
         settable_attributes = super()._get_settable_attributes_as_kwargs()
         if settable_attributes.pop("additional_capabilities", None):
             settable_attributes["capabilities"] = self._get_capabilties()

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1,29 +1,32 @@
-from hera.archive import Archive
+from argo_workflows.models import (
+    IoArgoprojWorkflowV1alpha1ArchiveStrategy,
+    IoArgoprojWorkflowV1alpha1TarStrategy,
+)
 
-from argo_workflows.models import IoArgoprojWorkflowV1alpha1ArchiveStrategy, IoArgoprojWorkflowV1alpha1TarStrategy
+from hera.archive import Archive
 
 
 class TestArchive:
     def test_build_sets_expected_fields(self):
         archive = Archive(disable_compression=True).build()
         assert isinstance(archive, IoArgoprojWorkflowV1alpha1ArchiveStrategy)
-        assert hasattr(archive, '_none')
+        assert hasattr(archive, "_none")
         assert archive._none
-        assert not hasattr(archive, 'tar')
-        assert not hasattr(archive, 'zip')
+        assert not hasattr(archive, "tar")
+        assert not hasattr(archive, "zip")
 
         archive = Archive(tar_compression_level=1).build()
         assert isinstance(archive, IoArgoprojWorkflowV1alpha1ArchiveStrategy)
-        assert hasattr(archive, 'tar')
+        assert hasattr(archive, "tar")
         assert isinstance(archive.tar, IoArgoprojWorkflowV1alpha1TarStrategy)
-        assert hasattr(archive.tar, 'compression_level')
+        assert hasattr(archive.tar, "compression_level")
         assert archive.tar.compression_level == 1
-        assert not hasattr(archive, '_none')
-        assert not hasattr(archive, 'zip')
+        assert not hasattr(archive, "_none")
+        assert not hasattr(archive, "zip")
 
         archive = Archive(zip=True).build()
         assert isinstance(archive, IoArgoprojWorkflowV1alpha1ArchiveStrategy)
-        assert hasattr(archive, 'zip')
+        assert hasattr(archive, "zip")
         assert archive.zip
-        assert not hasattr(archive, '_none')
-        assert not hasattr(archive, 'tar')
+        assert not hasattr(archive, "_none")
+        assert not hasattr(archive, "tar")

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1,0 +1,29 @@
+from hera.archive import Archive
+
+from argo_workflows.models import IoArgoprojWorkflowV1alpha1ArchiveStrategy, IoArgoprojWorkflowV1alpha1TarStrategy
+
+
+class TestArchive:
+    def test_build_sets_expected_fields(self):
+        archive = Archive(disable_compression=True).build()
+        assert isinstance(archive, IoArgoprojWorkflowV1alpha1ArchiveStrategy)
+        assert hasattr(archive, '_none')
+        assert archive._none
+        assert not hasattr(archive, 'tar')
+        assert not hasattr(archive, 'zip')
+
+        archive = Archive(tar_compression_level=1).build()
+        assert isinstance(archive, IoArgoprojWorkflowV1alpha1ArchiveStrategy)
+        assert hasattr(archive, 'tar')
+        assert isinstance(archive.tar, IoArgoprojWorkflowV1alpha1TarStrategy)
+        assert hasattr(archive.tar, 'compression_level')
+        assert archive.tar.compression_level == 1
+        assert not hasattr(archive, '_none')
+        assert not hasattr(archive, 'zip')
+
+        archive = Archive(zip=True).build()
+        assert isinstance(archive, IoArgoprojWorkflowV1alpha1ArchiveStrategy)
+        assert hasattr(archive, 'zip')
+        assert archive.zip
+        assert not hasattr(archive, '_none')
+        assert not hasattr(archive, 'tar')

--- a/tests/test_artifact.py
+++ b/tests/test_artifact.py
@@ -8,7 +8,7 @@ from argo_workflows.models import (
     SecretKeySelector,
 )
 
-from hera import Artifact, GCSArtifact, GitArtifact, HttpArtifact, S3Artifact, Task
+from hera import Artifact, GCSArtifact, GitArtifact, HttpArtifact, S3Artifact, Task, Archive
 
 
 class TestArtifact:
@@ -64,7 +64,7 @@ class TestArtifact:
 
 class TestS3Artifact:
     def test_as_argument_returns_expected_argument(self):
-        artifact = S3Artifact("a", "s3://test", "test", "test", archive={"zip": "test"})
+        artifact = S3Artifact("a", "s3://test", "test", "test", Archive(zip=True))
         argument = artifact.as_argument()
         assert isinstance(argument, IoArgoprojWorkflowV1alpha1Artifact)
         assert hasattr(argument, "name")
@@ -78,10 +78,10 @@ class TestS3Artifact:
         assert hasattr(argument, "archive")
         assert isinstance(argument.archive, IoArgoprojWorkflowV1alpha1ArchiveStrategy)
         assert hasattr(argument.archive, "zip")
-        assert argument.archive.zip == "test"
+        assert argument.archive.zip
 
     def test_as_output_returns_expected_output(self):
-        artifact = S3Artifact("a", "s3://test", "test", "test", archive={"zip": "test"})
+        artifact = S3Artifact("a", "s3://test", "test", "test", Archive(zip=True))
         output = artifact.as_output()
         assert isinstance(output, IoArgoprojWorkflowV1alpha1Artifact)
         assert hasattr(output, "name")
@@ -95,12 +95,12 @@ class TestS3Artifact:
         assert hasattr(output, "archive")
         assert isinstance(output.archive, IoArgoprojWorkflowV1alpha1ArchiveStrategy)
         assert hasattr(output.archive, "zip")
-        assert output.archive.zip == "test"
+        assert output.archive.zip
 
 
 class TestGCSArtifact:
     def test_as_argument_returns_expected_argument(self):
-        artifact = GCSArtifact("a", "gs://test", "test", "test", archive={"zip": "test"})
+        artifact = GCSArtifact("a", "gs://test", "test", "test", Archive(zip=True))
         argument = artifact.as_argument()
         assert isinstance(argument, IoArgoprojWorkflowV1alpha1Artifact)
         assert hasattr(argument, "name")
@@ -114,10 +114,10 @@ class TestGCSArtifact:
         assert hasattr(argument, "archive")
         assert isinstance(argument.archive, IoArgoprojWorkflowV1alpha1ArchiveStrategy)
         assert hasattr(argument.archive, "zip")
-        assert argument.archive.zip == "test"
+        assert argument.archive.zip
 
     def test_as_output_returns_expected_output(self):
-        artifact = GCSArtifact("a", "gs://test", "test", "test", archive={"zip": "test"})
+        artifact = GCSArtifact("a", "gs://test", "test", "test", Archive(zip=True))
         output = artifact.as_output()
         assert isinstance(output, IoArgoprojWorkflowV1alpha1Artifact)
         assert hasattr(output, "name")
@@ -131,7 +131,7 @@ class TestGCSArtifact:
         assert hasattr(output, "archive")
         assert isinstance(output.archive, IoArgoprojWorkflowV1alpha1ArchiveStrategy)
         assert hasattr(output.archive, "zip")
-        assert output.archive.zip == "test"
+        assert output.archive.zip
 
 
 class TestGitArtifact:

--- a/tests/test_artifact.py
+++ b/tests/test_artifact.py
@@ -8,7 +8,15 @@ from argo_workflows.models import (
     SecretKeySelector,
 )
 
-from hera import Artifact, GCSArtifact, GitArtifact, HttpArtifact, S3Artifact, Task, Archive
+from hera import (
+    Archive,
+    Artifact,
+    GCSArtifact,
+    GitArtifact,
+    HttpArtifact,
+    S3Artifact,
+    Task,
+)
 
 
 class TestArtifact:

--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -1,0 +1,25 @@
+from argo_workflows.models import IoArgoprojWorkflowV1alpha1Backoff
+
+from hera.backoff import Backoff
+
+
+class TestBackoff:
+    def test_converts_int_to_string_post_init(self):
+        bo = Backoff(factor=42)
+        assert bo.factor is not None
+        assert isinstance(bo.factor, str)
+        assert bo.factor == "42"
+
+    def test_build_returns_expected_backoff(self):
+        bo = Backoff()
+        fields = ["duration", "factor", "max_duration"]
+        assert set(list(vars(bo).keys())) == set(fields)
+        for field in fields:
+            bo = Backoff(**{field: "abc"}).build()
+            assert isinstance(bo, IoArgoprojWorkflowV1alpha1Backoff)
+            assert hasattr(bo, field)
+            assert bo.get(field) == "abc"
+            for other_field in fields:
+                if other_field == field:
+                    continue
+                assert not hasattr(bo, other_field)

--- a/tests/test_cron_workflow.py
+++ b/tests/test_cron_workflow.py
@@ -65,14 +65,47 @@ class TestCronWorkflow:
     def test_create_calls_service_create(self, schedule, setup):
         with CronWorkflow("test", schedule) as cw:
             cw.service = mock.Mock()
+            cw.service.create_cron_workflow = mock.Mock()
         result = cw.create()
         assert isinstance(result, CronWorkflow)
         cw.service.create_cron_workflow.assert_called_once_with(cw.build())
 
         cw = CronWorkflow("test", schedule)
         cw.service = mock.Mock()
+        cw.service.create_cron_workflow = mock.Mock()
         with pytest.raises(ValueError) as e:
             cw.in_context = True
             cw.create()
         cw.service.create_cron_workflow.assert_not_called()
         assert str(e.value) == "Cannot invoke `create` when using a Hera context"
+
+    def test_delete_calls_service_delete(self, schedule, setup):
+        with CronWorkflow("cw", schedule) as cw:
+            cw.service = mock.Mock()
+            cw.service.delete_cron_workflow = mock.Mock()
+        cw.delete()
+        cw.service.delete_cron_workflow.assert_called_once()
+
+    def test_delete_calls_service_suspend(self, schedule, setup):
+        with CronWorkflow("cw", schedule) as cw:
+            cw.service = mock.Mock()
+            cw.service.suspend_cron_workflow = mock.Mock()
+        cw.suspend()
+        cw.service.suspend_cron_workflow.assert_called_once()
+
+    def test_delete_calls_service_resume(self, schedule, setup):
+        with CronWorkflow("cw", schedule) as cw:
+            cw.service = mock.Mock()
+            cw.service.resume_cron_workflow = mock.Mock()
+        cw.resume()
+        cw.service.resume_cron_workflow.assert_called_once()
+
+    def test_update_adds_expected_fields_to_cw_self(self, schedule, setup):
+        with CronWorkflow("cw", schedule) as cw:
+            cw.service = mock.Mock()
+            get_cron_return = mock.Mock()
+            get_cron_return.metadata = {"resourceVersion": "42", "uid": "42"}
+            cw.service.get_cron_workflow = mock.Mock(return_value=get_cron_return)
+            cw.service.update_cron_workflow = mock.Mock()
+        cw.update()
+        cw.service.get_cron_workflow.assert_called_once()

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -11,7 +11,7 @@ from hera.value_from import ValueFrom
 class TestParameter:
     def test_init_raises_value_error(self):
         with pytest.raises(ValueError) as e:
-            Parameter("a", value_from=ValueFrom(default='42'), value="42")
+            Parameter("a", value_from=ValueFrom(default="42"), value="42")
         assert str(e.value) == "Cannot specify both `value` and `value_from` when instantiating `Parameter`"
 
     def test_as_name_returns_expected_parameter(self):

--- a/tests/test_retry_strategy.py
+++ b/tests/test_retry_strategy.py
@@ -1,0 +1,52 @@
+from argo_workflows.models import (
+    IoArgoprojWorkflowV1alpha1Backoff,
+    IoArgoprojWorkflowV1alpha1RetryStrategy,
+)
+
+from hera import Backoff, RetryPolicy, RetryStrategy
+
+
+class TestRetryStrategy:
+    def test_post_init_converts_str_to_int(self):
+        rs = RetryStrategy(limit=42)
+        assert rs.limit is not None
+        assert isinstance(rs.limit, str)
+        assert rs.limit == "42"
+
+    def test_build_adds_fields_as_expected(self):
+        s = RetryStrategy(backoff=Backoff(duration="1m")).build()
+        assert isinstance(s, IoArgoprojWorkflowV1alpha1RetryStrategy)
+        assert hasattr(s, "backoff")
+        assert isinstance(s.backoff, IoArgoprojWorkflowV1alpha1Backoff)
+        assert hasattr(s.backoff, "duration")
+        assert s.backoff.duration == "1m"
+        assert not hasattr(s, "expression")
+        assert not hasattr(s, "limit")
+        assert hasattr(s, "retry_policy")
+        assert s.retry_policy == "Always"
+
+        s = RetryStrategy(expression="abc").build()
+        assert isinstance(s, IoArgoprojWorkflowV1alpha1RetryStrategy)
+        assert hasattr(s, "expression")
+        assert s.expression == "abc"
+        assert not hasattr(s, "backoff")
+        assert not hasattr(s, "limit")
+        assert hasattr(s, "retry_policy")
+        assert s.retry_policy == "Always"
+
+        s = RetryStrategy(limit=42).build()
+        assert isinstance(s, IoArgoprojWorkflowV1alpha1RetryStrategy)
+        assert hasattr(s, "limit")
+        assert s.limit == "42"
+        assert not hasattr(s, "backoff")
+        assert not hasattr(s, "expression")
+        assert hasattr(s, "retry_policy")
+        assert s.retry_policy == "Always"
+
+        s = RetryStrategy(retry_policy=RetryPolicy.OnTransientError).build()
+        assert isinstance(s, IoArgoprojWorkflowV1alpha1RetryStrategy)
+        assert hasattr(s, "retry_policy")
+        assert s.retry_policy == "OnTransientError"
+        assert not hasattr(s, "limit")
+        assert not hasattr(s, "backoff")
+        assert not hasattr(s, "expression")

--- a/tests/test_security_context.py
+++ b/tests/test_security_context.py
@@ -38,68 +38,78 @@ def additional_capabilities():
     yield ["SYS_RAWIO"]
 
 
-def test_workflow_init_passes(privileged, run_as_user, run_as_group, fs_group, run_as_non_root):
-    wsc = WorkflowSecurityContext(
-        privileged=privileged,
-        run_as_user=run_as_user,
-        run_as_group=run_as_group,
-        fs_group=fs_group,
-        run_as_non_root=run_as_non_root,
-    )
+class TestWorkflowSecurityContext:
+    def test_workflow_init_passes(self, privileged, run_as_user, run_as_group, fs_group, run_as_non_root):
+        wsc = WorkflowSecurityContext(
+            privileged=privileged,
+            run_as_user=run_as_user,
+            run_as_group=run_as_group,
+            fs_group=fs_group,
+            run_as_non_root=run_as_non_root,
+        )
 
-    assert wsc.privileged == privileged
-    assert wsc.run_as_user == run_as_user
-    assert wsc.run_as_group == run_as_group
-    assert wsc.fs_group == fs_group
-    assert wsc.run_as_non_root == run_as_non_root
+        assert wsc.privileged == privileged
+        assert wsc.run_as_user == run_as_user
+        assert wsc.run_as_group == run_as_group
+        assert wsc.fs_group == fs_group
+        assert wsc.run_as_non_root == run_as_non_root
 
-
-def test_workflow_get_security_context(privileged, run_as_user, run_as_group, fs_group, run_as_non_root):
-    wsc = WorkflowSecurityContext(
-        privileged=privileged,
-        run_as_user=run_as_user,
-        run_as_group=run_as_group,
-        fs_group=fs_group,
-        run_as_non_root=run_as_non_root,
-    )
-    sc = wsc.get_security_context()
-    assert isinstance(sc, PodSecurityContext)
-    assert sc.privileged == privileged
-    assert sc.run_as_user == run_as_user
-    assert sc.run_as_group == run_as_group
-    assert sc.fs_group == fs_group
-    assert sc.run_as_non_root == run_as_non_root
-
-
-def test_task_init_passes(privileged, run_as_user, run_as_group, run_as_non_root, additional_capabilities):
-    sc = TaskSecurityContext(
-        privileged=privileged,
-        run_as_user=run_as_user,
-        run_as_group=run_as_group,
-        run_as_non_root=run_as_non_root,
-        additional_capabilities=additional_capabilities,
-    )
-
-    assert sc.privileged == privileged
-    assert sc.run_as_user == run_as_user
-    assert sc.run_as_group == run_as_group
-    assert sc.run_as_non_root == run_as_non_root
-    assert sc.additional_capabilities == additional_capabilities
+    def test_workflow_get_security_context(self, privileged, run_as_user, run_as_group, fs_group, run_as_non_root):
+        wsc = WorkflowSecurityContext(
+            privileged=privileged,
+            run_as_user=run_as_user,
+            run_as_group=run_as_group,
+            fs_group=fs_group,
+            run_as_non_root=run_as_non_root,
+        )
+        sc = wsc.get_security_context()
+        assert isinstance(sc, PodSecurityContext)
+        assert sc.privileged == privileged
+        assert sc.run_as_user == run_as_user
+        assert sc.run_as_group == run_as_group
+        assert sc.fs_group == fs_group
+        assert sc.run_as_non_root == run_as_non_root
 
 
-def test_task_get_security_context(privileged, run_as_user, run_as_group, run_as_non_root, additional_capabilities):
-    tsc = TaskSecurityContext(
-        privileged=privileged,
-        run_as_user=run_as_user,
-        run_as_group=run_as_group,
-        run_as_non_root=run_as_non_root,
-        additional_capabilities=additional_capabilities,
-    )
-    sc = tsc.build()
-    capabilities = Capabilities(add=additional_capabilities)
-    assert isinstance(sc, SecurityContext)
-    assert sc.privileged == privileged
-    assert sc.run_as_user == run_as_user
-    assert sc.run_as_group == run_as_group
-    assert sc.run_as_non_root == run_as_non_root
-    assert sc.capabilities == capabilities
+class TestTaskSecurityContext:
+    def test_task_init_passes(self, privileged, run_as_user, run_as_group, run_as_non_root, additional_capabilities):
+        sc = TaskSecurityContext(
+            privileged=privileged,
+            run_as_user=run_as_user,
+            run_as_group=run_as_group,
+            run_as_non_root=run_as_non_root,
+            additional_capabilities=additional_capabilities,
+        )
+
+        assert sc.privileged == privileged
+        assert sc.run_as_user == run_as_user
+        assert sc.run_as_group == run_as_group
+        assert sc.run_as_non_root == run_as_non_root
+        assert sc.additional_capabilities == additional_capabilities
+
+    def test_task_get_security_context(
+        self, privileged, run_as_user, run_as_group, run_as_non_root, additional_capabilities
+    ):
+        tsc = TaskSecurityContext(
+            privileged=privileged,
+            run_as_user=run_as_user,
+            run_as_group=run_as_group,
+            run_as_non_root=run_as_non_root,
+            additional_capabilities=additional_capabilities,
+        )
+        sc = tsc.build()
+        capabilities = Capabilities(add=additional_capabilities)
+        assert isinstance(sc, SecurityContext)
+        assert sc.privileged == privileged
+        assert sc.run_as_user == run_as_user
+        assert sc.run_as_group == run_as_group
+        assert sc.run_as_non_root == run_as_non_root
+        assert sc.capabilities == capabilities
+
+        tsc = TaskSecurityContext(
+            privileged=privileged,
+            run_as_user=run_as_user,
+            run_as_group=run_as_group,
+            run_as_non_root=run_as_non_root,
+        )
+        assert tsc._get_capabilties() is None

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -12,6 +12,7 @@ from argo_workflows.models import Toleration as _ArgoToleration
 from hera import (
     DAG,
     Artifact,
+    Backoff,
     ConfigMapEnv,
     ConfigMapEnvFrom,
     ConfigMapVolume,
@@ -251,7 +252,7 @@ print(42)
             resources=Resources(gpus=1),
             tolerations=[GPUToleration],
             node_selectors={"abc": "123-gpu"},
-            retry_strategy=RetryStrategy(backoff=dict(duration="1", max_duration="2")),
+            retry_strategy=RetryStrategy(backoff=Backoff(duration="1", max_duration="2")),
             daemon=True,
             affinity=affinity,
             memoize=Memoize("a", "b", "1h"),
@@ -297,7 +298,7 @@ print(42)
         assert not hasattr(tt, "affinity")
 
     def test_task_template_contains_expected_retry_strategy(self, no_op):
-        r = RetryStrategy(backoff=dict(duration="3", max_duration="9"))
+        r = RetryStrategy(backoff=Backoff(duration="3", max_duration="9"))
         t = Task("t", no_op, retry_strategy=r)
         assert t.retry_strategy is not None
         assert t.retry_strategy.backoff is not None
@@ -684,7 +685,7 @@ print(42)
         assert str(e.value) == "Cannot use both `dag` and `source`"
 
         with pytest.raises(ValueError) as e:
-            Task("t", dag=DAG("d"), template_ref="tref")
+            Task("t", dag=DAG("d"), template_ref=TemplateRef(name="tref"))
         assert str(e.value) == "Cannot use both `dag` and `template_ref`"
 
         with pytest.raises(ValueError) as e:

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -94,8 +94,8 @@ class TestTask:
         script = t._get_param_script_portion()
         assert (
             script == "import json\n"
-            "try: a = json.loads('''{{inputs.parameters.a}}''')\n"
-            "except: a = '''{{inputs.parameters.a}}'''\n"
+                      "try: a = json.loads('''{{inputs.parameters.a}}''')\n"
+                      "except: a = '''{{inputs.parameters.a}}'''\n"
         )
 
     def test_script_getter_returns_expected_string(self, op, typed_op):
@@ -103,23 +103,23 @@ class TestTask:
         script = t._get_script()
         assert (
             script == "import os\nimport sys\nsys.path.append(os.getcwd())\n"
-            "import json\n"
-            "try: a = json.loads('''{{inputs.parameters.a}}''')\n"
-            "except: a = '''{{inputs.parameters.a}}'''\n"
-            "\n"
-            "print(a)\n"
+                      "import json\n"
+                      "try: a = json.loads('''{{inputs.parameters.a}}''')\n"
+                      "except: a = '''{{inputs.parameters.a}}'''\n"
+                      "\n"
+                      "print(a)\n"
         )
 
         t = Task("t", typed_op, [{"a": 1}])
         script = t._get_script()
         assert (
             script == "import os\nimport sys\nsys.path.append(os.getcwd())\n"
-            "import json\n"
-            "try: a = json.loads('''{{inputs.parameters.a}}''')\n"
-            "except: a = '''{{inputs.parameters.a}}'''\n"
-            "\n"
-            "print(a)\n"
-            'return [{"a": (a, a)}]\n'
+                      "import json\n"
+                      "try: a = json.loads('''{{inputs.parameters.a}}''')\n"
+                      "except: a = '''{{inputs.parameters.a}}'''\n"
+                      "\n"
+                      "print(a)\n"
+                      'return [{"a": (a, a)}]\n'
         )
 
     def test_script_getter_parses_multi_line_function(self, long_op):
@@ -269,11 +269,11 @@ print(42)
         assert tt.name == "t"
         assert (
             tt.script.source == "import os\nimport sys\nsys.path.append(os.getcwd())\n"
-            "import json\n"
-            "try: a = json.loads('''{{inputs.parameters.a}}''')\n"
-            "except: a = '''{{inputs.parameters.a}}'''\n"
-            "\n"
-            "print(a)\n"
+                                "import json\n"
+                                "try: a = json.loads('''{{inputs.parameters.a}}''')\n"
+                                "except: a = '''{{inputs.parameters.a}}'''\n"
+                                "\n"
+                                "print(a)\n"
         )
         assert tt.inputs.parameters[0].name == "a"
         assert len(tt.tolerations) == 1
@@ -302,8 +302,8 @@ print(42)
         t = Task("t", no_op, retry_strategy=r)
         assert t.retry_strategy is not None
         assert t.retry_strategy.backoff is not None
-        assert t.retry_strategy.backoff["duration"] == "3"
-        assert t.retry_strategy.backoff["max_duration"] == "9"
+        assert t.retry_strategy.backoff.duration == "3"
+        assert t.retry_strategy.backoff.max_duration == "9"
 
         tt = t._build_template()
         assert tt is not None
@@ -685,7 +685,7 @@ print(42)
         assert str(e.value) == "Cannot use both `dag` and `source`"
 
         with pytest.raises(ValueError) as e:
-            Task("t", dag=DAG("d"), template_ref=TemplateRef(name="tref"))
+            Task("t", dag=DAG("d"), template_ref=TemplateRef(name="tref", template="abc"))
         assert str(e.value) == "Cannot use both `dag` and `template_ref`"
 
         with pytest.raises(ValueError) as e:

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -94,8 +94,8 @@ class TestTask:
         script = t._get_param_script_portion()
         assert (
             script == "import json\n"
-                      "try: a = json.loads('''{{inputs.parameters.a}}''')\n"
-                      "except: a = '''{{inputs.parameters.a}}'''\n"
+            "try: a = json.loads('''{{inputs.parameters.a}}''')\n"
+            "except: a = '''{{inputs.parameters.a}}'''\n"
         )
 
     def test_script_getter_returns_expected_string(self, op, typed_op):
@@ -103,23 +103,23 @@ class TestTask:
         script = t._get_script()
         assert (
             script == "import os\nimport sys\nsys.path.append(os.getcwd())\n"
-                      "import json\n"
-                      "try: a = json.loads('''{{inputs.parameters.a}}''')\n"
-                      "except: a = '''{{inputs.parameters.a}}'''\n"
-                      "\n"
-                      "print(a)\n"
+            "import json\n"
+            "try: a = json.loads('''{{inputs.parameters.a}}''')\n"
+            "except: a = '''{{inputs.parameters.a}}'''\n"
+            "\n"
+            "print(a)\n"
         )
 
         t = Task("t", typed_op, [{"a": 1}])
         script = t._get_script()
         assert (
             script == "import os\nimport sys\nsys.path.append(os.getcwd())\n"
-                      "import json\n"
-                      "try: a = json.loads('''{{inputs.parameters.a}}''')\n"
-                      "except: a = '''{{inputs.parameters.a}}'''\n"
-                      "\n"
-                      "print(a)\n"
-                      'return [{"a": (a, a)}]\n'
+            "import json\n"
+            "try: a = json.loads('''{{inputs.parameters.a}}''')\n"
+            "except: a = '''{{inputs.parameters.a}}'''\n"
+            "\n"
+            "print(a)\n"
+            'return [{"a": (a, a)}]\n'
         )
 
     def test_script_getter_parses_multi_line_function(self, long_op):
@@ -269,11 +269,11 @@ print(42)
         assert tt.name == "t"
         assert (
             tt.script.source == "import os\nimport sys\nsys.path.append(os.getcwd())\n"
-                                "import json\n"
-                                "try: a = json.loads('''{{inputs.parameters.a}}''')\n"
-                                "except: a = '''{{inputs.parameters.a}}'''\n"
-                                "\n"
-                                "print(a)\n"
+            "import json\n"
+            "try: a = json.loads('''{{inputs.parameters.a}}''')\n"
+            "except: a = '''{{inputs.parameters.a}}'''\n"
+            "\n"
+            "print(a)\n"
         )
         assert tt.inputs.parameters[0].name == "a"
         assert len(tt.tolerations) == 1

--- a/tests/test_volume_claim_strategy_gc.py
+++ b/tests/test_volume_claim_strategy_gc.py
@@ -1,0 +1,8 @@
+from hera import VolumeClaimGCStrategy
+
+
+class TestVolumeClaimGCStrategy:
+    def test_str_returns_expected_value(self):
+        assert str(VolumeClaimGCStrategy.OnWorkflowSuccess) == "OnWorkflowSuccess"
+        assert str(VolumeClaimGCStrategy.OnWorkflowCompletion) == "OnWorkflowCompletion"
+        assert len(VolumeClaimGCStrategy) == 2


### PR DESCRIPTION
This PR adds a `Backoff` and `Archive` custom objects. Note that the affinity field from the retry strategy object was removed because it does not do anything in response to setting the node anti-affinity field - that field is currently typed with `Any` (bool, str, NoneType, etc) as it's under development and is added as a placeholder for future iterations. 