### PR TITLE
Fix incorrect Optionals

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,8 +1,8 @@
 [mypy]
-mypy_path=src
 check_untyped_defs = True
+mypy_path=src
 no_implicit_optional = True
-strict_optional = False
+strict_optional = True
 
 [mypy-argo_workflows.*]
 ignore_missing_imports = True

--- a/src/hera/dag.py
+++ b/src/hera/dag.py
@@ -46,7 +46,7 @@ class DAG(IO):
         self.outputs = outputs or []
         self.tasks: List[Task] = []
 
-    def _build_templates(self) -> Optional[List[IoArgoprojWorkflowV1alpha1Template]]:
+    def _build_templates(self) -> List[IoArgoprojWorkflowV1alpha1Template]:
         """Assembles the templates from sub-DAGs of the DAG"""
         templates = [t for t in [t._build_template() for t in self.tasks] if t]
         # Assemble the templates from sub-dags

--- a/src/hera/task.py
+++ b/src/hera/task.py
@@ -711,7 +711,7 @@ class Task(IO):
 
         return deduced_params
 
-    def _get_param_script_portion(self) -> Optional[str]:
+    def _get_param_script_portion(self) -> str:
         """Constructs and returns a script that loads the parameters of the specified arguments. Since Argo passes
         parameters through {{input.parameters.name}} it can be very cumbersome for users to manage that. This creates a
         script that automatically imports json and loads/adds code to interpret each independent argument into the
@@ -788,7 +788,7 @@ class Task(IO):
             assert isinstance(self.source, str)
             return self.source
 
-    def _build_volume_mounts(self) -> Optional[List[VolumeMount]]:
+    def _build_volume_mounts(self) -> List[VolumeMount]:
         """Assembles the list of volumes to be mounted by the task.
 
         Returns
@@ -798,11 +798,11 @@ class Task(IO):
         """
         return [v._build_mount() for v in self.volumes]
 
-    def _build_volume_claim_templates(self) -> Optional[List[PersistentVolumeClaim]]:
+    def _build_volume_claim_templates(self) -> List[PersistentVolumeClaim]:
         """Assembles the list of volume claim templates to be created for the task."""
         return [v._build_claim_spec() for v in self.volumes if isinstance(v, Volume)]
 
-    def _build_persistent_volume_claims(self) -> Optional[List[ArgoVolume]]:
+    def _build_persistent_volume_claims(self) -> List[ArgoVolume]:
         """Assembles the list of Argo volume specifications"""
         return [
             v._build_claim_spec()


### PR DESCRIPTION
`Volume.size` is required, but was marked as `Optional[str]`. If you initialized without, you'd get an odd TypeError in `re` rather than saying unknown kwarg (and if we add an `if not None` before passing there, we'd get an error creating the Argo object wanting a not-`None` value).

```
>>> Volume(mount_path="abc")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<string>", line 9, in __init__
  File "/Users/jacobhayes/src/github.com/argoproj-labs/hera-workflows/src/hera/volumes.py", line 227, in __post_init__
    validate_storage_units(self.size)
  File "/Users/jacobhayes/src/github.com/argoproj-labs/hera-workflows/src/hera/validators.py", line 55, in validate_storage_units
    unit_search = re.search(pattern, value)
  File "/opt/homebrew/Cellar/python@3.9/3.9.14/Frameworks/Python.framework/Versions/3.9/lib/python3.9/re.py", line 201, in search
    return _compile(pattern, flags).search(string)
TypeError: expected string or bytes-like object
```

To fix that, I adjusted the `_Sized` base class to be a required string and just set `size: Optional[str]` on `EmptyDirVolume` (where it is not required).

`mypy` would have normally caught this (as we passed `self.size` into a function hinted as `: str`), but we had `strict_optional = False`. I changed that to `True` and it "caught" a couple other places we weren't handling the `Optional` case. Those turned out to just be "wrong" type hints (the functions never returned `Optional` at runtime), so I adjusted those (and a couple others mypy didn't care about) too.

```
$ mypy -p hera
src/hera/dag.py:54: error: Item "None" of "Optional[List[Any]]" has no attribute "__iter__" (not iterable)
src/hera/dag.py:66: error: Item "None" of "Optional[List[Any]]" has no attribute "__iter__" (not iterable)
src/hera/dag.py:81: error: Item "None" of "Optional[List[Any]]" has no attribute "__iter__" (not iterable)
src/hera/workflow.py:191: error: Unsupported left operand type for + ("None")
src/hera/workflow.py:191: note: Left operand is of type "Optional[List[Any]]"
Found 4 errors in 2 files (checked 40 source files)
```
