### PR TITLE
Lower coverage precision to reduce jitter

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,2 @@
+coverage:
+  precision: 1  # Don't bother with very small changes, which are often caused by subtle division differences when SLOC are removed.

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ exclude_lines =
     if TYPE_CHECKING:
     pragma: no cover
     raise NotImplementedError()
+precision = 1
 skip_covered = True
 show_missing = True
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,8 +8,6 @@ addopts = --durations=5 -vv
 [coverage:run]
 branch = true
 parallel = true
-omit =
-    src/hera/_task_input.py
 
 [coverage:report]
 exclude_lines =


### PR DESCRIPTION
Codecov was mad in https://github.com/argoproj-labs/hera-workflows/pull/309 because some source code was removed (thus "no longer covered"), causing some slight (negative) differences in the division. That should not matter (ideally, we'd be incentivised to remove code :), so this PR reduces the % diff decimal precision from 2 places to 1, which would have resulted in that PR passing, even without the additional `asserts`.
