### PR TITLE
Cleanup Workflow.dag checks

### DIFF
--- a/src/hera/workflow.py
+++ b/src/hera/workflow.py
@@ -181,7 +181,6 @@ class Workflow:
         """Assembles the spec of the workflow"""
         # Main difference between workflow and workflow template spec is that WT
         # (generally) doesn't have an entrypoint
-        assert self.dag is not None
         spec = IoArgoprojWorkflowV1alpha1WorkflowSpec()
         templates = self.dag._build_templates()
 
@@ -278,19 +277,16 @@ class Workflow:
 
     def add_task(self, t: Task) -> "Workflow":
         """Add a task to the workflow"""
-        assert self.dag is not None, "A `DAG` must be defined when adding a task to a workflow"
         self.dag.add_task(t)
         return self
 
     def add_tasks(self, *ts: Task) -> "Workflow":
         """Add a collection of tasks to the workflow"""
-        assert self.dag is not None, "A `DAG` must be defined when adding tasks to a workflow"
         self.dag.add_tasks(*ts)
         return self
 
     def create(self) -> "Workflow":
         """Creates the workflow"""
-        assert self.dag
         if self.in_context:
             raise ValueError("Cannot invoke `create` when using a Hera context")
 

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -365,20 +365,3 @@ class TestWorkflow:
 
         with Workflow('w', metrics=Metrics([Metric('a', 'b')])) as w:
             assert isinstance(w.metrics, Metrics)
-
-    def test_workflow_catches_none_dag_upon_task_insert(self):
-        w = Workflow('w')
-        assert w.dag is not None
-        assert w.dag.name == 'w'
-        w.dag = None
-        with pytest.raises(AssertionError) as e:
-            w.add_task(Task('t'))
-        assert str(e.value) == "A `DAG` must be defined when adding a task to a workflow"
-
-        with pytest.raises(AssertionError) as e:
-            w.add_tasks(Task('t1'), Task('t2'))
-        assert str(e.value) == "A `DAG` must be defined when adding tasks to a workflow"
-
-        w = Workflow('w', dag=DAG('w'))
-        assert w.dag is not None
-        assert w.dag.name == 'w'


### PR DESCRIPTION
https://github.com/argoproj-labs/hera-workflows/pull/309 added some extra `assert self.dag is not None` to `Workflow`, even though `self.dag` is now _always_ set/required. The added `test_workflow_catches_none_dag_upon_task_insert` test checks for this, but this is a degenerate case anyway, as `mypy` shows:

```
$ mypy -p hera -p tests
... # lots of other errors in tests, these aren't normally checked
tests/test_workflow.py:373: error: Incompatible types in assignment (expression has type "None", variable has type "DAG")
...
```

With https://github.com/argoproj-labs/hera-workflows/pull/311, we don't have to worry as much about codecov/coverage jitter, so the extra checks+test can be removed without making codecov mad. I figured making the code a bit more clear (ie: not make you second guess your mental model of `self.dag`) might be good, but feel free to close this if you still prefer the checks!
