### PR TITLE
Bugfix: env value_from_input was ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,6 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# vim
+*swp

--- a/examples/artifact_with_fanout.py
+++ b/examples/artifact_with_fanout.py
@@ -1,5 +1,6 @@
 from hera import Artifact, Task, Workflow
 
+
 def writer():
     import json
 

--- a/src/hera/env.py
+++ b/src/hera/env.py
@@ -61,10 +61,10 @@ class Env:
     @staticmethod
     def _sanitise_param_for_argo(v: str) -> str:
         """Argo has some strict parameter validation. To satisfy, we replace all ._ with a dash,
-        take only first 32 characters from a-zA-Z-, and append md5 digest of the original string."""
+        take only first 32 characters from a-zA-Z0-9-, and append md5 digest of the original string."""
         # NOTE move this to some general purpose utils?
-        replaced_dashes = v.translate(str.maketrans({e: '-' for e in "_."})) # type: ignore
-        legit_set = string.ascii_letters + '-'
+        replaced_dashes = v.translate(str.maketrans({e: '-' for e in "_."}))  # type: ignore
+        legit_set = string.ascii_letters + string.digits + '-'
         legit_prefix = "".join(islice((c for c in replaced_dashes if c in legit_set), 32))
         hash_suffix = hashlib.md5(v.encode("utf-8")).hexdigest()
         return f"{legit_prefix}-{hash_suffix}"

--- a/src/hera/env.py
+++ b/src/hera/env.py
@@ -1,5 +1,8 @@
+import hashlib
 import json
+import string
 from dataclasses import dataclass
+from itertools import islice
 from typing import Any, Optional, Union
 
 from argo_workflows.models import (
@@ -55,10 +58,33 @@ class Env:
     value: Optional[Any] = None
     value_from_input: Optional[Union[str, Parameter]] = None
 
+    @staticmethod
+    def _sanitise_param_for_argo(v: str) -> str:
+        """Argo has some strict parameter validation. To satisfy, we replace all ._ with a dash,
+        take only first 32 characters from a-zA-Z-, and append md5 digest of the original string."""
+        # NOTE move this to some general purpose utils?
+        replaced_dashes = v.translate(str.maketrans({e: '-' for e in "_."})) # type: ignore
+        legit_set = string.ascii_letters + '-'
+        legit_prefix = "".join(islice((c for c in replaced_dashes if c in legit_set), 32))
+        hash_suffix = hashlib.md5(v.encode("utf-8")).hexdigest()
+        return f"{legit_prefix}-{hash_suffix}"
+
+    @property
+    def param_name(self) -> str:
+        if not self.value_from_input:
+            raise ValueError(
+                "unexpected use of `param_name` -- without value_from_input, no param should be generated"
+            )
+        return Env._sanitise_param_for_argo(self.name)
+
+    def __post_init__(self):
+        if self.value is not None and self.value_from_input is not None:
+            raise ValueError("cannot specify both value and value_from_input")
+
     def build(self) -> EnvVar:
         """Constructs and returns the Argo environment specification"""
         if self.value_from_input is not None:
-            value = f"{{{{inputs.parameters.{self.name}}}}}"
+            value = f"{{{{inputs.parameters.{self.param_name}}}}}"
         elif isinstance(self.value, str):
             value = self.value
         else:

--- a/src/hera/task.py
+++ b/src/hera/task.py
@@ -707,7 +707,7 @@ class Task(IO):
                     if isinstance(spec.value_from_input, Parameter)
                     else spec.value_from_input
                 )
-                deduced_params.append(Parameter(name=spec.name, value=value))
+                deduced_params.append(Parameter(name=spec.param_name, value=value))
 
         return deduced_params
 

--- a/tests/test_sanitization.py
+++ b/tests/test_sanitization.py
@@ -7,7 +7,7 @@ from hera import Env
 
 def test_param_name_sanitization():
     suffix_hash = lambda v: hashlib.md5(v.encode("utf-8")).hexdigest()
-    no_change = "no-change"
+    no_change = "no-change-42"
     no_change_expected = f"{no_change}-{suffix_hash(no_change)}"
     assert no_change_expected == Env._sanitise_param_for_argo(no_change)
 

--- a/tests/test_sanitization.py
+++ b/tests/test_sanitization.py
@@ -1,0 +1,29 @@
+import hashlib
+
+import pytest
+
+from hera import Env
+
+
+def test_param_name_sanitization():
+    suffix_hash = lambda v: hashlib.md5(v.encode("utf-8")).hexdigest()
+    no_change = "no-change"
+    no_change_expected = f"{no_change}-{suffix_hash(no_change)}"
+    assert no_change_expected == Env._sanitise_param_for_argo(no_change)
+
+    dash_dot_replaced = "this_is.replaced"
+    dash_dot_replaced_expected = f"this-is-replaced-{suffix_hash(dash_dot_replaced)}"
+    assert dash_dot_replaced_expected == Env._sanitise_param_for_argo(dash_dot_replaced)
+
+    shortened_stripped = "a" * 16 + "(()){{}}" + "_" * 16 + "b" * 32
+    shortened_stripped_expected = "a" * 16 + "-" * 16 + "-" + suffix_hash(shortened_stripped)
+    assert shortened_stripped_expected == Env._sanitise_param_for_argo(shortened_stripped)
+
+    prefix_collision1 = "aa__"
+    prefix_collision2 = "aa.."
+    assert Env._sanitise_param_for_argo(prefix_collision1) != Env._sanitise_param_for_argo(prefix_collision2)
+
+
+def test_env_postinit():
+    with pytest.raises(ValueError):
+        Env(name="any", value="foo", value_from_input="bar")

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -528,12 +528,13 @@ print(42)
         t1 = Task("t1", "print(42)", env=[Env(name="IP", value_from_input=t.ip)])
         t1s = t1._build_script()
 
+        expected_param_name = Env._sanitise_param_for_argo("IP")
         assert t1s.env[0].name == "IP"
-        assert t1s.env[0].value == "{{inputs.parameters.IP}}"
+        assert t1s.env[0].value == f"{{{{inputs.parameters.{expected_param_name}}}}}"
 
         t1g = t1._build_arguments()
         assert t1g
-        assert t1g.parameters[0].name == "IP"
+        assert t1g.parameters[0].name == expected_param_name
         assert t1g.parameters[0].value == "{{tasks.t.ip}}"
 
     def test_task_adds_other_task_on_success(self):


### PR DESCRIPTION
In case of `Env` being specified via `value_from_input`, the actual value of the `value_from_input` is ignored and just its not-`None`ness is checked. We fix it here to use it. Current buggy state has the unfortunate consequence of having to name the env var the same as the parameter