### PR TITLE
Fix dag template not added for WFTemplates

### DIFF
--- a/examples/workflow_template.py
+++ b/examples/workflow_template.py
@@ -18,7 +18,7 @@ def tails():
     print("it was tails")
 
 
-with WorkflowTemplate("workflow-template") as w:
+with WorkflowTemplate("hera-workflow-templates", dag_name="coin-flip") as w:
     r = Task("r", random_code)
     Task("h", heads).on_other_result(r, "heads")
     Task("t", tails).on_other_result(r, "tails")

--- a/examples/workflow_with_template_ref.py
+++ b/examples/workflow_with_template_ref.py
@@ -1,4 +1,7 @@
-"""This example showcases how to run a workflow with a previously generated WorkflowTemplate with Hera"""
-from hera import Workflow
+from hera import Task, TemplateRef, Workflow
 
-Workflow("workflow-with-template-ref", workflow_template_ref="coin-flip-template").create()
+# The name of the DAG template is either the name of WorkflowTemplate (default), or the `dag_name`
+with Workflow("workflow-with-template-ref") as w:
+    Task("coin-flip", template_ref=TemplateRef(name="hera-workflow-templates", template="coin-flip"))
+
+w.create()

--- a/src/hera/workflow.py
+++ b/src/hera/workflow.py
@@ -113,7 +113,7 @@ class Workflow:
         metrics: Optional[Union[Metric, List[Metric], Metrics]] = None,
     ):
         self.name = validate_name(name)
-        dag_name = dag_name if dag_name is not None else self.name
+        dag_name = self.name is dag_name is None else dag_name
         self.dag = DAG(dag_name) if dag is None else dag
         self._service = service
         self.parallelism = parallelism

--- a/src/hera/workflow_template.py
+++ b/src/hera/workflow_template.py
@@ -18,7 +18,7 @@ class WorkflowTemplate(Workflow):
 
     def build(self) -> IoArgoprojWorkflowV1alpha1WorkflowTemplate:
         """Builds the workflow"""
-        spec = super()._build_spec(workflow_template=True)
+        spec = super()._build_spec()
         return IoArgoprojWorkflowV1alpha1WorkflowTemplate(metadata=self._build_metadata(), spec=spec)
 
     def create(self) -> "WorkflowTemplate":

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -365,3 +365,12 @@ class TestWorkflow:
 
         with Workflow('w', metrics=Metrics([Metric('a', 'b')])) as w:
             assert isinstance(w.metrics, Metrics)
+
+    def test_workflow_sets_dag_name(self):
+        w = Workflow("w", dag_name="dag-name")
+        assert w.dag.name == "dag-name"
+        assert w.build().spec.templates[0].name == "dag-name"
+
+        w = Workflow("w")
+        assert w.dag.name == "w"
+        assert w.build().spec.templates[0].name == "w"


### PR DESCRIPTION
A bug caused the DAG template to be omitted from `WorkflowTemplate`

In addition, I've made it possible to specify what the name of the dag template should be, which before always defaulted to the name of the workflow.