### PR TITLE
Add DCO and CLA ignore note to the contributor guideline

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,7 +2,7 @@
 
 While Hera is not a [Cloud Native Computing Foundation](https://www.cncf.io/) (CNCF) project, it supports, endorses, and
 echoes the code of conduct presented by the CNCF. The CNCF code of conduct can be found
-[here](https://github.com/cncf/foundation/blob/master/code-of-conduct.md). Full credit goes to the CNCF project for
+[here](https://github.com/cncf/foundation/blob/main/code-of-conduct.md). Full credit goes to the CNCF project for
 establishing the linked code of conduct principles.
 
 Instances of behaviors that are not aligned with the values proposed by CNCF can be reported to

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Please keep in mind the following guidelines and practices when contributing to 
 1. Your commit must be signed. Hera uses [an application](https://github.com/apps/dco) that enforces the Developer 
    Certificate of Origin (DCO). Currently, a Contributor License Agreement 
    ([CLA](https://github.com/cla-assistant/cla-assistant)) check also appears on submitted pull requests. This can be
-   safely ignored as the Argo Project is slowly migrating projects to DCO
+   safely ignored and is **not** a requirement for contributions to hera-workflows. This is an artifact as the Argo Project is slowly migrating projects from CLA to DCO. 
 1. Use `tox -e format` to format the repository code. `tox -e format` maps to a usage of
    [black](https://github.com/psf/black), and the repository adheres to whatever `black` uses as its strict pep8 format.
    No questions asked

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,4 +23,4 @@ Please keep in mind the following guidelines and practices when contributing to 
 ### Code of Conduct
 
 Please be mindful of and adhere to the Linux Foundation's
-[Code of Conduct](https://lfprojects.org/policies/code-of-conduct) when contributing to Horovod.
+[Code of Conduct](https://lfprojects.org/policies/code-of-conduct) when contributing to hera-workflows.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,5 +22,5 @@ Please keep in mind the following guidelines and practices when contributing to 
 
 ### Code of Conduct
 
-Please be mindful of and adhere to the Linux Foundation's
-[Code of Conduct](https://lfprojects.org/policies/code-of-conduct) when contributing to hera-workflows.
+Please be mindful of and adhere to the CNCF's
+[Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md) when contributing to hera-workflows.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,10 @@ appreciates your willingness to dedicate some time to Hera for the benefit of ev
 
 Please keep in mind the following guidelines and practices when contributing to Hera:
 
+1. Your commit must be signed. Hera uses [an application](https://github.com/apps/dco) that enforces the Developer 
+   Certificate of Origin (DCO). Currently, a Contributor License Agreement 
+   ([CLA](https://github.com/cla-assistant/cla-assistant)) check also appears on submitted pull requests. This can be
+   safely ignored as the Argo Project is slowly migrating projects to DCO
 1. Use `tox -e format` to format the repository code. `tox -e format` maps to a usage of
    [black](https://github.com/psf/black), and the repository adheres to whatever `black` uses as its strict pep8 format.
    No questions asked


### PR DESCRIPTION
See conversation in CNCF Slack workspace: https://cloud-native.slack.com/archives/C020XM04CUW/p1666353572915679