### PR TITLE
Support unset workflow parameters to enable GitOps style submissions of workflow + usage of parameterized templates

### DIFF
--- a/docs/examples/gitops.md
+++ b/docs/examples/gitops.md
@@ -1,0 +1,31 @@
+# Sample GitOps pattern
+
+This example showcases the hello world example of Hera in a GitOps style. The workflow gets a global parameter set
+called `msg`. This parameter has neither a `value` nor a `value_from` set. This supports the generation of a workflow
+YAML file that has the full definition and supports submission via `argo submit hello.yaml -p msg="hello"`. This
+parameterizes the workflow global parameter called `msg` to have a `value` of `hello`. This `hello` is then passed to
+the `Task` via the global parameter `w.get_parameter('msg')`, which sets the `'{{workflow.parameters.msg}}'` on the
+task parameter definition.
+
+## Workflow definition (Python)
+
+```python
+from hera import Task, Workflow, Parameter
+
+
+def say(msg: str):
+    print(msg)
+
+
+with Workflow("hera-gitops-say", parameters=[Parameter('msg')]) as w:
+    Task("t", say, inputs=[w.get_parameter('msg')])
+
+with open('hello.yaml', 'w') as f:
+    f.write(w.to_yaml())
+```
+
+## GitOps style/local submission
+
+```shell
+argo submit hello.yaml -p msg="hello"
+```

--- a/docs/examples/gitops.md
+++ b/docs/examples/gitops.md
@@ -10,7 +10,7 @@ task parameter definition.
 ## Workflow definition (Python)
 
 ```python
-from hera import Task, Workflow, Parameter
+from hera import Parameter, Task, Workflow
 
 
 def say(msg: str):

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,6 +38,7 @@ Welcome to Hera's documentation!
    examples/dynamic_fanout_fanin_artifacts
    examples/env
    examples/existing_volume
+   examples/gitops
    examples/global_host
    examples/global_parameters
    examples/gpu

--- a/examples/gitops.py
+++ b/examples/gitops.py
@@ -1,0 +1,22 @@
+"""
+This example showcases the hello world example of Hera in a GitOps style. The workflow gets a global parameter set
+called `msg`. This parameter has neither a `value` nor a `value_from` set. This supports the generation of a workflow
+YAML file that has the full definition and supports submission via `argo submit hello.yaml -p msg="hello"`. This
+parameterizes the workflow global parameter called `msg` to have a `value` of `hello`. This `hello` is then passed to
+the `Task` via the global parameter `w.get_parameter('msg')`, which sets the `'{{workflow.parameters.msg}}'` on the
+task parameter definition.
+"""
+from hera import Task, Workflow, Parameter
+
+
+def say(msg: str):
+    print(msg)
+
+
+with Workflow("hera-gitops-say", parameters=[Parameter('msg')]) as w:
+    Task("t", say, inputs=[w.get_parameter('msg')])
+
+with open('hello.yaml', 'w') as f:
+    f.write(w.to_yaml())
+
+# the above is followed up by issuing `argo submit hello.yaml -p msg="hello"`

--- a/examples/gitops.py
+++ b/examples/gitops.py
@@ -6,7 +6,7 @@ parameterizes the workflow global parameter called `msg` to have a `value` of `h
 the `Task` via the global parameter `w.get_parameter('msg')`, which sets the `'{{workflow.parameters.msg}}'` on the
 task parameter definition.
 """
-from hera import Task, Workflow, Parameter
+from hera import Parameter, Task, Workflow
 
 
 def say(msg: str):

--- a/src/hera/parameter.py
+++ b/src/hera/parameter.py
@@ -35,6 +35,8 @@ class Parameter:
         default: Optional[str] = None,
         value_from: Optional[ValueFrom] = None,
     ) -> None:
+        if value is not None and value_from is not None:
+            raise ValueError("Cannot specify both `value` and `value_from` when instantiating `Parameter`")
         self.name = name
         self.value = str(value) if value is not None else None
         self.default = str(default) if default is not None else None

--- a/src/hera/parameter.py
+++ b/src/hera/parameter.py
@@ -18,7 +18,9 @@ class Parameter:
         The name of the task to take input from. The task's results are expected via stdout. Specifically, the task is
         expected to perform the script illustrated in Examples.
     value: Optional[str] = None
-        Value of the parameter, as an index into some field of the task.
+        Value of the parameter, as an index into some field of the task. If this is left as `None`, along with
+        `value_from` being left as `None`, as is the case in GitOps patterns, the submitter has to likely supply the
+        parameter value via the ArgoCLI.
     default: Optional[str] = None
         Default value of the parameter in case the `value` cannot be obtained based on the specification.
     value_from: Optional[ValueFrom] = None
@@ -33,8 +35,6 @@ class Parameter:
         default: Optional[str] = None,
         value_from: Optional[ValueFrom] = None,
     ) -> None:
-        if value is not None and value_from is not None:
-            raise ValueError("Cannot specify both `value` and `value_from` when instantiating `Parameter`")
         self.name = name
         self.value = str(value) if value is not None else None
         self.default = str(default) if default is not None else None
@@ -53,15 +53,10 @@ class Parameter:
         parameter = IoArgoprojWorkflowV1alpha1Parameter(
             name=self.name,
         )
-        if self.value:
+        if self.value is not None:
             setattr(parameter, "value", self.value)
         elif self.value_from is not None:
             setattr(parameter, "value_from", self.value_from.build())
-        else:
-            raise ValueError(
-                f"Parameter with name `{parameter.name}` cannot be interpreted as argument "
-                "as neither of the following args are set: `value`, `value_from`, `default`"
-            )
         return parameter
 
     def as_input(self) -> IoArgoprojWorkflowV1alpha1Parameter:
@@ -87,14 +82,15 @@ class Parameter:
         This is useful in situations where we want to concatenate string values such as
         Task.args=["echo", wf.get_parameter("message")].
         """
-        if self.value:
-            return self.value
-        raise ValueError("Cannot represent `Parameter` as string as `value` is not set")
+        if self.value is None:
+            raise ValueError("Cannot represent `Parameter` as string as `value` is not set")
+        return self.value
 
     @property
     def contains_item(self) -> bool:
-        """Check whether the parmeter contains an argo item reference"""
-        if self.value is not None:
-            if "{{item" in self.value:
-                return True
+        """Check whether the parameter contains an argo item reference"""
+        if self.value is None:
+            return False
+        elif "{{item" in self.value:
+            return True
         return False

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -80,3 +80,16 @@ class TestParameter:
     def test_contains_value_returns_expected_false(self):
         p = Parameter("a", value="42")
         assert not p.contains_item
+
+    def test_value_and_value_from_not_set_together(self):
+        with pytest.raises(ValueError) as e:
+            Parameter('a', value='42', value_from=ValueFrom())
+
+        p = Parameter('a', value='42')
+        assert p.value_from is None
+        assert p.value is not None
+
+        p = Parameter('a', value_from=ValueFrom(path='/test'))
+        assert p.value is None
+        assert p.value_from is not None
+        assert p.value_from.path == "/test"

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -36,14 +36,6 @@ class TestParameter:
         assert hasattr(arg.value_from, "path")
         assert arg.value_from.path == "abc"
 
-    def test_as_argument_raises_value_error_on_misspec(self):
-        with pytest.raises(ValueError) as e:
-            Parameter("a").as_argument()
-        assert (
-            str(e.value) == "Parameter with name `a` cannot be interpreted as argument "
-            "as neither of the following args are set: `value`, `value_from`, `default`"
-        )
-
     def test_as_input_returns_expected_parameter(self):
         param = Parameter("a", default="42").as_input()
         assert isinstance(param, IoArgoprojWorkflowV1alpha1Parameter)


### PR DESCRIPTION
Fixes: #346 

This PR removes the Hera validation of `value` + `value_from` in the `Parameter` implementation. This allows setting a `Parameter` at the global workflow level via the `Workflow(..., parameters=[Parameter(...)])` field. This will define a workflow containing a global parameter with some name but _without_ a value. With that, a `Task` can obtain a workflow global parameter reference via the `Workflow.get_parameter(...)` API, which exposes the `'{{workflow.parameters.msg}}'` to the `Task` parameter. The value of this parameter can be set via an Argo CLI parameter specification. For testing purposes I created a `WorkflowTemplate`:

```python
from hera import Task, Parameter, WorkflowTemplate


def say(msg: str) -> None:
    print(msg)


with WorkflowTemplate(
    "hera-workflow-templates",
    dag_name="dag",
    parameters=[Parameter("msg")]
) as wt:
    Task('say', inputs=[wt.get_parameter("msg")])

wt.create()
```

The above results in the creation of a workflow template called `hera-workflow-templates`:
<img width="1644" alt="Screen Shot 2022-11-10 at 3 52 08 PM" src="https://user-images.githubusercontent.com/18152652/201222763-0df43480-8f22-44c2-acaf-f45859d9ca46.png">

In order to use this workflow template and submit a workflow I issued the following command:
```shell
argo submit --from workflowtemplate/hera-workflow-templates -p msg="hello"
```

This resulted in the successful creation and execution of the following workflow (highlighted parameter value):
<img width="1645" alt="Screen Shot 2022-11-10 at 3 53 10 PM" src="https://user-images.githubusercontent.com/18152652/201222895-4cbce023-affc-4c13-bc3d-5689d7fa481d.png">

In addition to a workflow template I also functionally tested that after generating a `workflow.yaml` file from the `hello_hera.py` example, parameterized by a global `msg` parameter, I can submit the workflow YAML file via 
```shell
argo submit hello.yaml -p msg="hello"
```

I skipped those screenshots because they are very similar to the ones above.

CC: @elliotgunton 
CC: @samj1912 
CC: @dbragdon1