### PR TITLE
Misc follow ups from #351

### DIFF
--- a/docs/examples/gpu.md
+++ b/docs/examples/gpu.md
@@ -20,7 +20,7 @@ def do():
     | Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
     |                               |                      |               MIG M. |
     |===============================+======================+======================|
-    |   0  Tesla K80           Off  | 00000000:00:05.0 Off |                    0 |
+    |   0  Tesla T4            Off  | 00000000:00:05.0 Off |                    0 |
     | N/A   67C    P8    33W / 149W |      0MiB / 11441MiB |      0%      Default |
     |                               |                      |                  N/A |
     +-------------------------------+----------------------+----------------------+
@@ -39,14 +39,14 @@ def do():
 
 
 with Workflow("gpu") as w:
-    gke_k80_gpu = {"cloud.google.com/gke-accelerator": "nvidia-tesla-t4"}
+    gke_t4_gpu = {"cloud.google.com/gke-accelerator": "nvidia-tesla-t4"}
     d = Task(
         "do",
         do,
         image="horovod/horovod:0.22.1",
         resources=Resources(gpus=1),
         tolerations=[GPUToleration],
-        node_selectors=gke_k80_gpu,
+        node_selectors=gke_t4_gpu,
     )
 
 w.create()

--- a/examples/gpu.py
+++ b/examples/gpu.py
@@ -18,7 +18,7 @@ def do():
     | Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
     |                               |                      |               MIG M. |
     |===============================+======================+======================|
-    |   0  Tesla K80           Off  | 00000000:00:05.0 Off |                    0 |
+    |   0  Tesla T4            Off  | 00000000:00:05.0 Off |                    0 |
     | N/A   67C    P8    33W / 149W |      0MiB / 11441MiB |      0%      Default |
     |                               |                      |                  N/A |
     +-------------------------------+----------------------+----------------------+
@@ -37,14 +37,14 @@ def do():
 
 
 with Workflow("gpu") as w:
-    gke_k80_gpu = {"cloud.google.com/gke-accelerator": "nvidia-tesla-t4"}
+    gke_t4_gpu = {"cloud.google.com/gke-accelerator": "nvidia-tesla-t4"}
     d = Task(
         "do",
         do,
         image="horovod/horovod:0.22.1",
         resources=Resources(gpus=1),
         tolerations=[GPUToleration],
-        node_selectors=gke_k80_gpu,
+        node_selectors=gke_t4_gpu,
     )
 
 w.create()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,10 @@ max-line-length = 119
 
 [tool.pytest.ini_options]
 addopts = "-ra -q"
+filterwarnings = [
+    # Hide the hera.host_config deprecations
+    'ignore:.*is deprecated in favor of `global_config.GlobalConfig',
+]
 
 [tool.isort]
 known_first_party = ["hera"]

--- a/src/hera/global_config.py
+++ b/src/hera/global_config.py
@@ -50,17 +50,7 @@ class _GlobalConfig:
 
     def reset(self) -> None:
         """Resets the global config container to its initial state"""
-        self.__dict__.clear()
-        self._token = None
-
-        self.host = None
-        self.verify_ssl = True
-        self.api_version = "argoproj.io/v1alpha1"
-        self.namespace = "default"
-        self.image = "python:3.7"
-        self.service_account_name = None
-        self.task_post_init_hooks = ()
-        self.workflow_post_init_hooks = ()
+        self.__dict__.clear()  # Wipe instance values to fallback to the class defaults
 
     @property
     def token(self) -> Optional[str]:

--- a/src/hera/host_config.py
+++ b/src/hera/host_config.py
@@ -6,8 +6,6 @@ from typing import Optional, Union
 
 from hera.global_config import GlobalConfig
 
-_api_version = GlobalConfig.api_version
-
 
 def set_global_api_version(v: str) -> None:
     """Sets the global API version that is used to control the `api_version` field on Argo payload submissions.
@@ -31,9 +29,6 @@ def get_global_api_version() -> str:
     return GlobalConfig.api_version
 
 
-_service_account_name = GlobalConfig.service_account_name
-
-
 def set_global_service_account_name(sa: Optional[str]) -> None:
     """Sets the service account to use for workflow submissions on a global level"""
     warnings.warn(
@@ -50,9 +45,6 @@ def get_global_service_account_name() -> Optional[str]:
         "`global_config.GlobalConfig.service_account_name` and will be removed in a future version"
     )
     return GlobalConfig.service_account_name
-
-
-_verify_ssl = GlobalConfig.verify_ssl
 
 
 def set_global_verify_ssl(v: bool) -> None:
@@ -76,9 +68,6 @@ def get_global_verify_ssl() -> bool:
     return GlobalConfig.verify_ssl
 
 
-_host = GlobalConfig.host
-
-
 def set_global_host(h: Optional[str]) -> None:
     """Sets the Argo Workflows host at a global level so services can use it"""
     warnings.warn(
@@ -95,9 +84,6 @@ def get_global_host() -> Optional[str]:
         "`global_config.GlobalConfig.host` and will be removed in a future version"
     )
     return GlobalConfig.host
-
-
-_token = GlobalConfig.token
 
 
 def set_global_token(t: Union[Optional[str], Callable[[], Optional[str]]]) -> None:
@@ -118,9 +104,6 @@ def get_global_token() -> Optional[str]:
     return GlobalConfig.token
 
 
-_namespace = GlobalConfig.namespace
-
-
 def set_global_namespace(n: str) -> None:
     """Sets the Argo Workflows namespace at the global level so services can use it"""
     warnings.warn(
@@ -137,9 +120,6 @@ def get_global_namespace() -> str:
         "`global_config.GlobalConfig.namespace` and will be removed in a future version"
     )
     return GlobalConfig.namespace
-
-
-_image = GlobalConfig.image
 
 
 def set_global_task_image(image: str) -> None:

--- a/tests/test_global_config.py
+++ b/tests/test_global_config.py
@@ -9,7 +9,6 @@ class TestGlobalConfig:
         assert c.host is None
         c.host = '123'
         assert c.host == '123'
-        c.reset()
 
     def test_token(self):
         c = _GlobalConfig()
@@ -18,42 +17,36 @@ class TestGlobalConfig:
         assert c.token == '123'
         c.token = lambda: '123'
         assert c.token == '123'
-        c.reset()
 
     def test_verify_ssl(self):
         c = _GlobalConfig()
         assert c.verify_ssl
         c.verify_ssl = False
         assert not c.verify_ssl
-        c.reset()
 
     def test_api_version(self):
         c = _GlobalConfig()
         assert c.api_version == "argoproj.io/v1alpha1"
         c.api_version = "123"
         assert c.api_version == "123"
-        c.reset()
 
     def test_namespace(self):
         c = _GlobalConfig()
         assert c.namespace == "default"
         c.namespace = "123"
         assert c.namespace == "123"
-        c.reset()
 
     def test_image(self):
         c = _GlobalConfig()
         assert c.image == "python:3.7"
         c.image = "123"
         assert c.image == "123"
-        c.reset()
 
     def test_service_account_name(self):
         c = _GlobalConfig()
         assert c.service_account_name is None
         c.service_account_name = "123"
         assert c.service_account_name == "123"
-        c.reset()
 
     def test_task_post_init_hooks(self):
         c = _GlobalConfig()
@@ -71,8 +64,6 @@ class TestGlobalConfig:
         c.task_post_init_hooks = (hook1, hook2)
         assert len(c.task_post_init_hooks) == 2
 
-        c.reset()
-
     def test_workflow_post_init_hooks(self):
         c = _GlobalConfig()
         assert c.workflow_post_init_hooks == ()
@@ -88,4 +79,3 @@ class TestGlobalConfig:
 
         c.workflow_post_init_hooks = (hook1, hook2)
         assert len(c.workflow_post_init_hooks) == 2
-        c.reset()

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -45,7 +45,6 @@ from hera import (
     Volume,
     WorkflowStatus,
 )
-from hera.global_config import _GlobalConfig
 
 
 class TestTask:

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -10,7 +10,6 @@ from argo_workflows.models import (
 )
 
 from hera.dag import DAG
-from hera.global_config import _GlobalConfig
 from hera.host_alias import HostAlias
 from hera.host_config import set_global_service_account_name
 from hera.metric import Metric, Metrics


### PR DESCRIPTION
Saw a couple things we could cleanup when reviewing #351, so just PRing since I got to the review late! :smile:

- Update more k80->t4 refs
- Remove old private host_config vars (if we left these for softer backwards compatibility, even though private, they wouldn't work the same anyway since they're set only on import)
- Hide hera.host_config deprecations in pytest
- Simplify GlobalConfig.reset
- Remove unused config reset and imports in tests
