### PR TITLE
Remove "." in name validation

### DIFF
--- a/src/hera/validators.py
+++ b/src/hera/validators.py
@@ -19,8 +19,6 @@ def validate_name(name: str, max_length: Optional[int] = None) -> str:
     """
     if max_length and len(name) > max_length:
         raise ValueError(f"Name is too long. Max length: {max_length}, found: {len(name)}")
-    if "." in name:
-        raise ValueError("Name cannot include a dot")
     if "_" in name:
         raise ValueError("Name cannot include an underscore")
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -10,9 +10,6 @@ def test_validate_name():
         validate_name("test", max_length=1)
     assert str(e.value) == "Name is too long. Max length: 1, found: 4"
     with pytest.raises(ValueError) as e:
-        validate_name("test.42")
-    assert str(e.value) == "Name cannot include a dot"
-    with pytest.raises(ValueError) as e:
         validate_name("test_42")
     assert str(e.value) == "Name cannot include an underscore"
     with pytest.raises(ValueError) as e:


### PR DESCRIPTION
* Argo allows dots in Workflow names

Fixes #353 

![image](https://user-images.githubusercontent.com/17798778/201731920-0df4b3d2-d5f1-4207-844b-558ad485b565.png)
