### PR TITLE
feat: Make affinity `_build` interfaces public

### DIFF
--- a/src/hera/affinity.py
+++ b/src/hera/affinity.py
@@ -51,7 +51,7 @@ class NodeSelectorRequirement:
         self.operator: str = str(operator)
         self.values = values
 
-    def _build(self) -> Optional[ArgoNodeSelectorRequirement]:
+    def build(self) -> Optional[ArgoNodeSelectorRequirement]:
         """Assembles the Argo node selector requirement"""
         if self.values is not None:
             return ArgoNodeSelectorRequirement(
@@ -88,17 +88,17 @@ class NodeSelectorTerm:
         self.expressions = expressions
         self.fields = fields
 
-    def _build(self) -> Optional[ArgoNodeSelectorTerm]:
+    def build(self) -> Optional[ArgoNodeSelectorTerm]:
         """Assembles the Argo node selector term"""
         term = ArgoNodeSelectorTerm()
 
         if self.expressions is not None:
-            match_expressions = [expression._build() for expression in self.expressions]
+            match_expressions = [expression.build() for expression in self.expressions]
             if any(match_expressions):
                 setattr(term, "match_expressions", match_expressions)
 
         if self.fields is not None:
-            match_fields = [field._build() for field in self.fields]
+            match_fields = [field.build() for field in self.fields]
             if any(match_fields):
                 setattr(term, "match_fields", match_fields)
 
@@ -127,9 +127,9 @@ class PreferredSchedulingTerm:
         assert 1 <= weight <= 100, "Node selector weight for scheduling term preference should be between 1 and 100"
         self.weight = weight
 
-    def _build(self) -> Optional[ArgoPreferredSchedulingTerm]:
+    def build(self) -> Optional[ArgoPreferredSchedulingTerm]:
         """Assembles the Argo preferred scheduling term"""
-        node_selector_term = self.node_selector_term._build()
+        node_selector_term = self.node_selector_term.build()
         if node_selector_term is not None:
             return ArgoPreferredSchedulingTerm(
                 preference=node_selector_term,
@@ -160,7 +160,7 @@ class LabelSelectorRequirement:
         self.operator: str = str(operator)
         self.values = values
 
-    def _build(self) -> ArgoLabelSelectorRequirement:
+    def build(self) -> ArgoLabelSelectorRequirement:
         """Assembles the Argo label selector requirement"""
         if self.values is not None:
             return ArgoLabelSelectorRequirement(
@@ -197,12 +197,12 @@ class LabelSelector:
         self.label_selector_requirements = label_selector_requirements
         self.match_labels = match_labels
 
-    def _build(self) -> Optional[ArgoLabelSelector]:
+    def build(self) -> Optional[ArgoLabelSelector]:
         """Assembles the Argo label selector"""
         selector = ArgoLabelSelector()
 
         if self.label_selector_requirements is not None:
-            match_expressions = [expression._build() for expression in self.label_selector_requirements]
+            match_expressions = [expression.build() for expression in self.label_selector_requirements]
             if any(match_expressions):
                 setattr(selector, "match_expressions", match_expressions)
 
@@ -245,15 +245,15 @@ class PodAffinityTerm:
         self.namespace_selector = namespace_selector
         self.namespaces = namespaces
 
-    def _build(self) -> Optional[ArgoPodAffinityTerm]:
+    def build(self) -> Optional[ArgoPodAffinityTerm]:
         """Assembles the pod affinity term"""
         term = ArgoPodAffinityTerm(topology_key=self.topology_key)
 
         if self.label_selector is not None:
-            setattr(term, "label_selector", self.label_selector._build())
+            setattr(term, "label_selector", self.label_selector.build())
 
         if self.namespace_selector is not None:
-            setattr(term, "namespace_selector", self.namespace_selector._build())
+            setattr(term, "namespace_selector", self.namespace_selector.build())
 
         if self.namespaces is not None:
             setattr(term, "namespaces", self.namespaces)
@@ -287,10 +287,10 @@ class WeightedPodAffinityTerm:
         assert 1 <= weight <= 100, "Pod affinity term weight should be between 1 and 100"
         self.weight = weight
 
-    def _build(self) -> ArgoWeightedPodAffinityTerm:
+    def build(self) -> ArgoWeightedPodAffinityTerm:
         """Assembles the weighted pod affinity term"""
         return ArgoWeightedPodAffinityTerm(
-            pod_affinity_term=self.pod_affinity_term._build(),
+            pod_affinity_term=self.pod_affinity_term.build(),
             weight=self.weight,
         )
 
@@ -318,13 +318,13 @@ class PodAffinity:
         self.weighted_pod_affinities = weighted_pod_affinities
         self.pod_affinity_terms = pod_affinity_terms
 
-    def _build(self) -> Optional[ArgoPodAffinity]:
+    def build(self) -> Optional[ArgoPodAffinity]:
         """Assembles the pod affinity"""
         affinity = ArgoPodAffinity()
 
         if self.weighted_pod_affinities is not None:
             preferred_during_scheduling_ignored_during_execution = [
-                term._build() for term in self.weighted_pod_affinities
+                term.build() for term in self.weighted_pod_affinities
             ]
             if any(preferred_during_scheduling_ignored_during_execution):
                 setattr(
@@ -334,7 +334,7 @@ class PodAffinity:
                 )
 
         if self.pod_affinity_terms:
-            required_during_scheduling_ignored_during_execution = [term._build() for term in self.pod_affinity_terms]
+            required_during_scheduling_ignored_during_execution = [term.build() for term in self.pod_affinity_terms]
             if any(required_during_scheduling_ignored_during_execution):
                 setattr(
                     affinity,
@@ -370,13 +370,13 @@ class PodAntiAffinity:
         self.weighted_pod_affinities = weighted_pod_affinities
         self.pod_affinity_terms = pod_affinity_terms
 
-    def _build(self) -> Optional[ArgoPodAntiAffinity]:
+    def build(self) -> Optional[ArgoPodAntiAffinity]:
         """Assembles the pod anti affinity"""
         affinity = ArgoPodAntiAffinity()
 
         if self.weighted_pod_affinities is not None:
             preferred_during_scheduling_ignored_during_execution = [
-                term._build() for term in self.weighted_pod_affinities
+                term.build() for term in self.weighted_pod_affinities
             ]
             if any(preferred_during_scheduling_ignored_during_execution):
                 setattr(
@@ -386,7 +386,7 @@ class PodAntiAffinity:
                 )
 
         if self.pod_affinity_terms is not None:
-            required_during_scheduling_ignored_during_execution = [term._build() for term in self.pod_affinity_terms]
+            required_during_scheduling_ignored_during_execution = [term.build() for term in self.pod_affinity_terms]
             if any(required_during_scheduling_ignored_during_execution):
                 setattr(
                     affinity,
@@ -417,10 +417,10 @@ class NodeSelector:
     def __init__(self, terms: Optional[List[NodeSelectorTerm]] = None):
         self.terms = terms
 
-    def _build(self) -> Optional[ArgoNodeSelector]:
+    def build(self) -> Optional[ArgoNodeSelector]:
         """Assembles the node selector"""
         if self.terms is not None:
-            terms = [term._build() if term else None for term in self.terms]
+            terms = [term.build() if term else None for term in self.terms]
             if any(terms):
                 return ArgoNodeSelector(node_selector_terms=terms)
         return None
@@ -449,13 +449,13 @@ class NodeAffinity:
         self.preferred_scheduling_terms = preferred_scheduling_terms
         self.node_selector = node_selector
 
-    def _build(self) -> Optional[ArgoNodeAffinity]:
+    def build(self) -> Optional[ArgoNodeAffinity]:
         """Assembles the node affinity"""
         affinity = ArgoNodeAffinity()
 
         if self.preferred_scheduling_terms is not None:
             preferred_during_scheduling_ignored_during_execution = [
-                term._build() for term in self.preferred_scheduling_terms
+                term.build() for term in self.preferred_scheduling_terms
             ]
             if any(preferred_during_scheduling_ignored_during_execution):
                 setattr(
@@ -465,7 +465,7 @@ class NodeAffinity:
                 )
 
         if self.node_selector is not None:
-            required_during_scheduling_ignored_during_execution = self.node_selector._build()
+            required_during_scheduling_ignored_during_execution = self.node_selector.build()
             if required_during_scheduling_ignored_during_execution:
                 setattr(
                     affinity,
@@ -507,20 +507,20 @@ class Affinity:
         self.pod_anti_affinity = pod_anti_affinity
         self.node_affinity = node_affinity
 
-    def _build(self) -> Optional[ArgoAffinity]:
+    def build(self) -> Optional[ArgoAffinity]:
         """Assembles an affinity"""
         affinity = ArgoAffinity()
 
         if self.pod_affinity is not None:
-            pod_affinity = self.pod_affinity._build()
+            pod_affinity = self.pod_affinity.build()
             setattr(affinity, "pod_affinity", pod_affinity)
 
         if self.pod_anti_affinity is not None:
-            pod_anti_affinity = self.pod_anti_affinity._build()
+            pod_anti_affinity = self.pod_anti_affinity.build()
             setattr(affinity, "pod_anti_affinity", pod_anti_affinity)
 
         if self.node_affinity is not None:
-            node_affinity = self.node_affinity._build()
+            node_affinity = self.node_affinity.build()
             setattr(affinity, "node_affinity", node_affinity)
 
         if (

--- a/src/hera/task.py
+++ b/src/hera/task.py
@@ -925,7 +925,7 @@ class Task(IO):
         else:
             setattr(template, "container", self._build_container())
 
-        affinity = self.affinity._build() if self.affinity else None
+        affinity = self.affinity.build() if self.affinity else None
         if affinity is not None:
             setattr(template, "affinity", affinity)
 

--- a/src/hera/workflow.py
+++ b/src/hera/workflow.py
@@ -244,7 +244,7 @@ class Workflow:
             )
 
         if self.affinity is not None:
-            setattr(spec, "affinity", self.affinity._build())
+            setattr(spec, "affinity", self.affinity.build())
 
         if self.node_selector is not None:
             setattr(spec, "node_selector", self.node_selector)

--- a/tests/test_affinity.py
+++ b/tests/test_affinity.py
@@ -37,14 +37,14 @@ def test_node_selector_requirement_returns_expected_spec():
     assert node_selector_requirement.operator == LabelOperator.In
     assert node_selector_requirement.values == ["value"]
 
-    spec = node_selector_requirement._build()
+    spec = node_selector_requirement.build()
     assert isinstance(spec, ArgoNodeSelectorRequirement)
     assert spec.key == "a"
     assert spec.operator == "In"
     assert spec.values == ["value"]
 
     node_selector_requirement = NodeSelectorRequirement("a", LabelOperator.In)
-    spec = node_selector_requirement._build()
+    spec = node_selector_requirement.build()
     assert isinstance(spec, ArgoNodeSelectorRequirement)
     assert spec.key == "a"
     assert spec.operator == "In"
@@ -57,7 +57,7 @@ def test_node_selector_term_returns_expected_spec():
     assert node_selector_term.expressions == expressions
     assert node_selector_term.fields == fields
 
-    spec = node_selector_term._build()
+    spec = node_selector_term.build()
     assert isinstance(spec, ArgoNodeSelectorTerm)
     assert spec.match_expressions == [
         ArgoNodeSelectorRequirement(key="a", operator="In", values=["value"]),
@@ -67,13 +67,13 @@ def test_node_selector_term_returns_expected_spec():
     ]
 
     node_selector_term = NodeSelectorTerm()
-    spec = node_selector_term._build()
+    spec = node_selector_term.build()
     assert spec is None
 
 
 def test_preferred_scheduling_term_returns_expected_spec():
     term = PreferredSchedulingTerm(NodeSelectorTerm(), 1)
-    spec = term._build()
+    spec = term.build()
     assert spec is None
 
     expressions = [Expression("a", LabelOperator.In, ["value"])]
@@ -86,7 +86,7 @@ def test_preferred_scheduling_term_returns_expected_spec():
     assert term.node_selector_term == node_selector_term
     assert term.weight == 1
 
-    spec = term._build()
+    spec = term.build()
     assert isinstance(spec, ArgoPreferredSchedulingTerm)
     assert spec.preference is not None
     assert spec.preference.match_expressions == [
@@ -104,14 +104,14 @@ def test_label_selector_requirement():
     assert label_selector_requirement.operator == LabelOperator.In
     assert label_selector_requirement.values == ["value"]
 
-    spec = label_selector_requirement._build()
+    spec = label_selector_requirement.build()
     assert isinstance(spec, ArgoLabelSelectorRequirement)
     assert spec.key == "a"
     assert spec.operator == "In"
     assert spec.values == ["value"]
 
     label_selector_requirement = LabelSelectorRequirement("a", LabelOperator.In)
-    spec = label_selector_requirement._build()
+    spec = label_selector_requirement.build()
     assert isinstance(spec, ArgoLabelSelectorRequirement)
     assert spec.key == "a"
     assert spec.operator == "In"
@@ -123,7 +123,7 @@ def test_label_selector():
         match_labels={"a": "b"},
     )
 
-    spec = label_selector._build()
+    spec = label_selector.build()
     assert isinstance(spec, ArgoLabelSelector)
     assert spec.match_expressions == [
         ArgoLabelSelectorRequirement(key="a", operator="In", values=["value"]),
@@ -135,7 +135,7 @@ def test_label_selector():
         label_selector_requirements=[LabelSelectorRequirement("a", LabelOperator.In)], match_labels={"a": "b"}
     )
 
-    spec = label_selector._build()
+    spec = label_selector.build()
     assert isinstance(spec, ArgoLabelSelector)
     assert spec.match_expressions == [
         ArgoLabelSelectorRequirement(key="a", operator="In"),
@@ -144,7 +144,7 @@ def test_label_selector():
     assert spec.match_labels == {"a": "b"}
 
     label_selector = LabelSelector()
-    spec = label_selector._build()
+    spec = label_selector.build()
     assert spec is None
 
 
@@ -165,7 +165,7 @@ def test_pod_affinity_term():
     assert pod_affinity_term.namespace_selector == label_selector
     assert pod_affinity_term.namespaces == ["a"]
 
-    spec = pod_affinity_term._build()
+    spec = pod_affinity_term.build()
     assert isinstance(spec, ArgoPodAffinityTerm)
     assert spec.label_selector.match_expressions == [
         ArgoLabelSelectorRequirement(key="a", operator="In", values=["value"]),
@@ -176,7 +176,7 @@ def test_pod_affinity_term():
     assert spec.namespaces == ["a"]
 
     pod_affinity_term = PodAffinityTerm("a")
-    spec = pod_affinity_term._build()
+    spec = pod_affinity_term.build()
     assert spec is None
 
 
@@ -196,7 +196,7 @@ def test_weighted_pod_affinity_term():
         ),
     )
 
-    spec = weighted_pod_affinity_term._build()
+    spec = weighted_pod_affinity_term.build()
     assert isinstance(spec, ArgoWeightedPodAffinityTerm)
     assert spec.weight == 1
     assert spec.pod_affinity_term.label_selector.match_expressions == [
@@ -247,7 +247,7 @@ def test_pod_affinity():
         ],
     )
 
-    spec = pod_affinity._build()
+    spec = pod_affinity.build()
     assert isinstance(spec, ArgoPodAffinity)
     assert spec.required_during_scheduling_ignored_during_execution == [
         ArgoPodAffinityTerm(
@@ -269,7 +269,7 @@ def test_pod_affinity():
     ]
 
     pod_affinity = PodAffinity()
-    spec = pod_affinity._build()
+    spec = pod_affinity.build()
     assert spec is None
 
 
@@ -311,7 +311,7 @@ def test_pod_anti_affinity():
             )
         ],
     )
-    spec = pod_affinity._build()
+    spec = pod_affinity.build()
     assert isinstance(spec, ArgoPodAntiAffinity)
     assert spec.required_during_scheduling_ignored_during_execution == [
         ArgoPodAffinityTerm(
@@ -333,7 +333,7 @@ def test_pod_anti_affinity():
     ]
 
     pod_affinity = PodAntiAffinity()
-    spec = pod_affinity._build()
+    spec = pod_affinity.build()
     assert spec is None
 
 
@@ -358,7 +358,7 @@ def test_node_affinity():
         ),
     )
 
-    spec = node_affinity._build()
+    spec = node_affinity.build()
     assert isinstance(spec, ArgoNodeAffinity)
     assert spec.preferred_during_scheduling_ignored_during_execution == [
         ArgoPreferredSchedulingTerm(
@@ -491,17 +491,17 @@ def test_affinity():
             ),
         ),
     )
-    assert affinity._build() is not None
+    assert affinity.build() is not None
 
     affinity = Affinity()
-    assert affinity._build() is None
+    assert affinity.build() is None
 
 
 def test_node_selector_returns_none_on_empty_spec():
     node_selector = NodeSelector()
-    assert node_selector._build() is None
+    assert node_selector.build() is None
 
 
 def test_node_affinity_returns_none_on_empty_spec():
     node_affinity = NodeAffinity()
-    assert node_affinity._build() is None
+    assert node_affinity.build() is None


### PR DESCRIPTION
Hera uses public `build` interfaces. This decision was made in order to support users who want to assemble the `argo_workflows` objects and further modify them. I noticed that affinity does not use public interfaces for `build`. This PR adjusts that so the design is consistent between Hera objects