### PR TITLE
Add support for exit DAGs to `Task`

### DIFF
--- a/src/hera/dag.py
+++ b/src/hera/dag.py
@@ -1,5 +1,8 @@
 """The implementation of a Hera workflow for Argo-based workflows"""
-from typing import List, Optional, Union
+from typing import List, Optional, Union, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from hera.task import Task
 
 from argo_workflows.models import (
     IoArgoprojWorkflowV1alpha1DAGTask,
@@ -12,7 +15,7 @@ from argo_workflows.models import Volume as ArgoVolume
 from hera.artifact import Artifact
 from hera.io import IO
 from hera.parameter import Parameter
-from hera.task import Task
+
 from hera.validators import validate_name
 
 
@@ -43,7 +46,7 @@ class DAG(IO):
         self.name = validate_name(name)
         self.inputs = inputs or []
         self.outputs = outputs or []
-        self.tasks: List[Task] = []
+        self.tasks: List["Task"] = []
 
     def _build_templates(self) -> List[IoArgoprojWorkflowV1alpha1Template]:
         """Assembles the templates from sub-DAGs of the DAG"""
@@ -119,12 +122,12 @@ class DAG(IO):
         self.in_context = False
         dag_context.exit()
 
-    def add_task(self, t: Task) -> "DAG":
+    def add_task(self, t: "Task") -> "DAG":
         """Add a task to the DAG. Note that tasks are added automatically when the DAG context is used"""
         self.tasks.append(t)
         return self
 
-    def add_tasks(self, *ts: Task) -> "DAG":
+    def add_tasks(self, *ts: "Task") -> "DAG":
         """Add a collection of tasks to the DAG.
 
         Note that tasks are added automatically when the DAG context is used

--- a/src/hera/task.py
+++ b/src/hera/task.py
@@ -829,9 +829,9 @@ class Task(IO):
             v._build_claim_spec()
             for v in self.volumes
             if isinstance(v, ExistingVolume)
-               or isinstance(v, SecretVolume)
-               or isinstance(v, EmptyDirVolume)
-               or isinstance(v, ConfigMapVolume)
+            or isinstance(v, SecretVolume)
+            or isinstance(v, EmptyDirVolume)
+            or isinstance(v, ConfigMapVolume)
         ]
 
     def _build_env(self) -> Tuple[List[EnvVar], List[EnvFromSource]]:


### PR DESCRIPTION
Currently, tasks can only support single tasks to execute on task exits. Specifically, it only supports that have the `source` field set but not the `DAG` field set. In addition, they do not support running DAGs as exit tasks. This PR adds support for running DAGs on task exits. Note that passed in DAGs must be pure DAGs for otherwise passing in a `Task(..., dag=DAG(...))` results in duplicating templates, which is neither supported by Argo nor deduplicated by Hera. Since tasks can only take either a `source` or `DAG`, the `on_exit` interface now only accepts a `Task` with a `source` or a pure `DAG`.

Fixes: #361 
CC: @ipl31