### PR TITLE
Automate the release/changelog process

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,46 @@
+
+- name: semver:major
+  description: A change requiring a major version bump
+  color: f9d0c4
+- name: semver:minor
+  description: A change requiring a minor version bump
+  color: f9d0c4
+- name: semver:patch
+  description: A change requiring a patch version bump
+  color: f9d0c4
+- name: type:bug
+  description: A general bug
+  color: e3d9fc
+- name: type:dependency-upgrade
+  description: A dependency upgrade
+  color: e3d9fc
+- name: type:documentation
+  description: A documentation update
+  color: e3d9fc
+- name: type:enhancement
+  description: A general enhancement
+  color: e3d9fc
+- name: type:question
+  description: A user question
+  color: e3d9fc
+- name: type:skip-changelog
+  description: A change that does not require a changelog entry
+  color: e3d9fc
+- name: type:task
+  description: A general task
+  color: e3d9fc
+- name: type:informational
+  description: Provides information or notice to the community
+  color: e3d9fc
+- name: type:poll
+  description: Request for feedback from the community
+  color: e3d9fc
+- name: note:ideal-for-contribution
+  description: An issue that a contributor can help us with
+  color: 54f7a8
+- name: note:on-hold
+  description: We can't start working on this issue yet
+  color: 54f7a8
+- name: note:good-first-issue
+  description: A good first issue to get started with
+  color: 54f7a8

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,33 @@
+template: $CHANGES
+name-template: v$RESOLVED_VERSION
+tag-template: $RESOLVED_VERSION
+categories:
+  - title: ⭐️ Enhancements
+    labels:
+      - type:enhancement
+  - title: "\U0001F41E Bug Fixes"
+    labels:
+      - type:bug
+  - title: "\U0001F4D4 Documentation"
+    labels:
+      - type:documentation
+  - title: ⛏ Dependency Upgrades
+    labels:
+      - type:dependency-upgrade
+  - title: "\U0001F6A7 Tasks"
+    labels:
+      - type:task
+exclude-labels:
+  - type:question
+  - type:skip-changelog
+version-resolver:
+  major:
+    labels:
+      - semver:major
+  minor:
+    labels:
+      - semver:minor
+  patch:
+    labels:
+      - semver:patch
+  default: patch

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   pull_request:
+    branches:
+      - main
 
 jobs:
   test:
@@ -126,29 +128,3 @@ jobs:
           directory: .tox/
           fail_ci_if_error: true
         if: ${{ always() }}
-
-  publish:
-    needs: [ coverage, test ]
-    if: success() && ( github.ref == 'refs/heads/main' )
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: setup python 3.7
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.7'
-
-      - name: Install base dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install poetry twine
-
-      - name: Build and publish
-        env:
-          PYPI_USERNAME: __token__
-          PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: |
-          poetry build
-          twine upload -u __token__ -p $PYPI_PASSWORD --skip-existing dist/* 

--- a/.github/workflows/minimal-labels.yml
+++ b/.github/workflows/minimal-labels.yml
@@ -1,0 +1,29 @@
+name: Minimal Labels
+on:
+  pull_request:
+    types:
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+jobs:
+  semver:
+    name: Minimal Semver Labels
+    runs-on:
+      - ubuntu-latest
+    steps:
+      - uses: mheap/github-action-required-labels@v2
+        with:
+          count: 1
+          labels: semver:major, semver:minor, semver:patch
+          mode: exactly
+  type:
+    name: Minimal Type Labels
+    runs-on:
+      - ubuntu-latest
+    steps:
+      - uses: mheap/github-action-required-labels@v2
+        with:
+          count: 1
+          labels: type:bug, type:dependency-upgrade, type:documentation, type:enhancement, type:question, type:task, type:skip-changelog
+          mode: exactly

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,28 @@
+---
+name: PyPI publish
+# Publish once a maintainer clicks publish on a draft release
+on:
+  release:
+    types: [released]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: Install base dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install poetry twine
+      - name: Bump version number
+        run: poetry version ${{ github.event.release.tag_name }}
+      - name: Build and publish
+        env:
+          PYPI_USERNAME: __token__
+          PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          poetry build
+          twine upload -u __token__ -p $PYPI_PASSWORD --skip-existing dist/* 

--- a/.github/workflows/release-updater.yml
+++ b/.github/workflows/release-updater.yml
@@ -1,0 +1,18 @@
+name: Update Draft Release
+on:
+  push:
+    branches:
+      - main
+jobs:
+  update:
+    permissions:
+      # write permission is required to create a github release
+      contents: write
+    name: Update Draft Release
+    runs-on:
+      - ubuntu-latest
+    steps:
+      - id: release-drafter
+        uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,45 @@
+# Hera release process
+
+Hera's release process relies on [Release drafter](https://github.com/release-drafter/release-drafter) for automatically deciding the version to bump, generating a changelog in the Github Release.
+
+Release drafter automatically creates draft releases that are visible to maintainers and keep it up-to-date with the appropriate git-tag, version number and changelog based on the merged pull-requests and their labels.
+
+## Versioning
+
+Each pull-request must be labeled with one of the following labels -
+
+- semver:major
+- semver:minor
+- semver:patch
+
+Once the pull-request is merged, based on the semver label on the merged pull-request, Release drafter will automatically bump up the draft release version.
+
+## Changelog
+
+Each pull-request must be labeled with one of the following labels -
+
+- type:bug
+- type:dependency-upgrade
+- type:documentation
+- type:enhancement
+- type:question
+- type:task
+- type:skip-changelog
+
+Once the pull-request is merged, based on the type label on the merged pull-request, Release drafter will automatically generate changelog entries with the PR title and the PR type.
+
+## Publishing a new version
+
+Once the maintainers are ready to publish a new version, they can go to the Github draft release at https://github.com/argoproj-labs/hera-workflows/releases.
+
+They will find a draft release with the appropriate version and changelog that is only visible to maintainers on the repository.
+
+<img width="1032" alt="image" src="https://user-images.githubusercontent.com/16130816/206037787-a72d4356-df29-4a41-969b-b96e42942fca.png">
+
+They should then click on the edit icon on the top left, and make minor updates to the release if needed.
+
+Once ready, they can click "Publish release".
+
+<img width="492" alt="image" src="https://user-images.githubusercontent.com/16130816/206037939-72fde009-b5e1-41ed-8f6a-8da7557ca08a.png">
+
+This will create a new git tag and release on the repository and kick off a Github action that will automatically publish the current contents on the hera repository to PyPI with the release version.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.poetry]
 name = "hera-workflows"
-version = "4.2.0"
+# The version is automatically substituted by the CI 
+version = "0.0.0-dev"
 description = "Hera is a Python framework for constructing and submitting Argo Workflows. The main goal of Hera is to make Argo Workflows more accessible by abstracting away some setup that is typically necessary for constructing Argo workflows."
 authors = ["Flaviu Vadan <flaviu.vadan@dynotx.com>", "Asgeir Berland <asgeir.berland@oda.com>"]
 license = "MIT"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -6,13 +6,12 @@ def test_version():
     version_info = __version_info__
 
     assert isinstance(version, str)
-    assert len(version_info) == 3
+    assert len(version_info) >= 3
     try:
         int(version_info[0])
         int(version_info[1])
-        if "rc" in version_info[2]:
-            pass
-        else:
-            int(version_info[2])
+        int(version_info[2])
     except Exception:
         raise
+    if len(version_info) == 4:
+        assert ("dev" in version_info[3] or "rc" in version_info[3])


### PR DESCRIPTION
Fixes #379 
Fixes #334 

This PR adds an automated version bumping/changlog generation process and an easy to use release process that can be released via the UI. See RELEASE.md for more details.

Rendered [RELEASE.md](https://github.com/samj1912/hera-workflows/blob/github-workflow/RELEASE.md)