### PR TITLE
Add a script and tox target to auto-generate example markdowns

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Please keep in mind the following guidelines and practices when contributing to 
    No questions asked
 1. Use `tox` to lint, run tests, and typecheck on the project
 1. Add unit tests for any new code you write
-1. Add an example, or extend an existing example, with any new features you may add
+1. Add an example, or extend an existing example, with any new features you may add. Use `tox -e generate-examples` to ensure that the documentation and examples are in sync.
 1. Increment the version of Hera. Hera adheres to [semantic versioning](https://semver.org/). This increment can be
    performed in the [pyproject.toml](https://github.com/argoproj-labs/hera-workflows/blob/main/pyproject.toml) file. A
    [CHANGELOG](https://github.com/argoproj-labs/hera-workflows/blob/main/CHANGELOG.md) entry is expected along with

--- a/docs/examples/any_success_all_fail.md
+++ b/docs/examples/any_success_all_fail.md
@@ -1,4 +1,6 @@
-# Any success all fail
+# Any Success All Fail
+
+
 
 ```python
 from hera import Task, Workflow
@@ -30,5 +32,4 @@ with Workflow("any-success-all-fail") as w:
     t2.when_all_failed(t3)
 
 w.create()
-
 ```

--- a/docs/examples/artifact_with_fanout.md
+++ b/docs/examples/artifact_with_fanout.md
@@ -1,4 +1,6 @@
-# Artifact with fanout
+# Artifact With Fanout
+
+
 
 ```python
 from hera import Artifact, Task, Workflow
@@ -39,5 +41,4 @@ with Workflow("artifact-with-fanout") as w:
     w_t >> f_t >> c_t
 
 w.create()
-
 ```

--- a/docs/examples/coin_flip.md
+++ b/docs/examples/coin_flip.md
@@ -1,9 +1,9 @@
-# Workflow Template
+# Coin Flip
 
 This example showcases the classic conditional workflow coin-flip.
 
 ```python
-from hera import Task, WorkflowTemplate
+from hera import Task, Workflow
 
 
 def random_code():
@@ -21,10 +21,14 @@ def tails():
     print("it was tails")
 
 
-with WorkflowTemplate("hera-workflow-templates", dag_name="coin-flip") as w:
+# assumes you used `hera.set_global_token` and `hera.set_global_host` so that the workflow can be submitted
+with Workflow("coin-flip") as w:
     r = Task("r", random_code)
-    Task("h", heads).on_other_result(r, "heads")
-    Task("t", tails).on_other_result(r, "tails")
+    h = Task("h", heads)
+    t = Task("t", tails)
+
+    h.on_other_result(r, "heads")
+    t.on_other_result(r, "tails")
 
 w.create()
 ```

--- a/docs/examples/complex_expr.md
+++ b/docs/examples/complex_expr.md
@@ -1,9 +1,9 @@
-# Complex expr
+# Complex Expr
 
 This example showcases how to string together complex expressions.
 
-This example is a Python replica of [expression-reusing-verbose-snippets](https://github.com/argoproj/argo-workflows/blob/master/examples/expression-reusing-verbose-snippets.yaml) from [Argo Workflows examples](https://github.com/argoproj/argo-workflows/tree/master/examples).
-
+This example is a python replica of
+https://github.com/argoproj/argo-workflows/blob/master/examples/expression-reusing-verbose-snippets.yaml
 
 ```python
 import base64
@@ -54,5 +54,5 @@ with Workflow("expression-reusing-verbose-snippets-", generate_name=True) as w:
         image="debian:9.4",
     )
 
-w.create()
+print(w.to_yaml())
 ```

--- a/docs/examples/conditional.md
+++ b/docs/examples/conditional.md
@@ -1,6 +1,6 @@
 # Conditional
 
-This example showcases conditional execution on success, failure, and error.
+This example showcases conditional execution on success, failure, and error
 
 ```python
 from hera import Task, Workflow

--- a/docs/examples/container.md
+++ b/docs/examples/container.md
@@ -1,6 +1,6 @@
 # Container
 
-This example showcases how to run a container, rather than a Python, function, as the payload of a task in Hera.
+This example showcases how to run a container, rather than a Python, function, as the payload of a task in Hera
 
 ```python
 from hera import Task, Workflow

--- a/docs/examples/custom_script.md
+++ b/docs/examples/custom_script.md
@@ -1,10 +1,9 @@
-# Custom script
+# Custom Script
 
 This example showcases how to run a custom script rather than a python function in Hera
 
 ```python
 from hera import Parameter, Task, Workflow
-
 
 # If the source function of a task has a return type of "str" in its annotation,
 # the task will resolve the function before creation.

--- a/docs/examples/daemon.md
+++ b/docs/examples/daemon.md
@@ -1,8 +1,9 @@
 # Daemon
 
-Enablement of https://argoproj.github.io/argo-workflows/variables/. This example creates two tasks, one of the
-Tasks is a deamond task and its IP address is shared with the second task. The daemoned task operates as server,
-serving an example payload, with the second task operating as a client, making HTTP requests to the server
+Enablement of https://argoproj.github.io/argo-workflows/variables/
+This example creates two tasks, one of the Tasks is a deamond task and its IP address is shared with the second task
+The daemoned task operates as server, serving an example payload, with the second task operating as a client, making
+http requests to the server.
 
 ```python
 from hera import Env, Task, Workflow

--- a/docs/examples/default_param_overwrite.md
+++ b/docs/examples/default_param_overwrite.md
@@ -1,4 +1,4 @@
-# Default param overwrite
+# Default Param Overwrite
 
 This example showcases how a Python source can be scheduled with default parameters as kwargs but overwritten
 conditionally.

--- a/docs/examples/diamond.md
+++ b/docs/examples/diamond.md
@@ -1,7 +1,7 @@
 # Diamond
 
-This example showcases the classic diamond workflow that is used as an example by Argo documentation and other
-libraries.
+This example showcases the classic diamond workflow that is used as an example by Argo documentation and
+other libraries.
 
 ```python
 from hera import Task, Workflow

--- a/docs/examples/dynamic_fanout.md
+++ b/docs/examples/dynamic_fanout.md
@@ -1,4 +1,4 @@
-# Dynamic fanout
+# Dynamic Fanout
 
 This example showcases how clients can use Hera to dynamically generate tasks that process outputs from one task in
 parallel. This is useful for batch jobs and instances where clients do not know ahead of time how many tasks/entities

--- a/docs/examples/dynamic_fanout_container.md
+++ b/docs/examples/dynamic_fanout_container.md
@@ -1,8 +1,8 @@
-# Dynamic fanout with containers
+# Dynamic Fanout Container
 
 This example showcases how clients can use Hera to dynamically generate tasks that process outputs from one task in
-parallel. Differ from dynamic_fanout.py, this example uses a container to generate the tasks and the dynamically created
-tasks are also container only.
+parallel. Differ from dynamic_fanout.py, this example uses a container to generate the tasks and the dynamically
+created tasks are also container only.
 More details can be found here: https://github.com/argoproj-labs/hera-workflows/issues/250
 
 ```python

--- a/docs/examples/dynamic_fanout_fanin.md
+++ b/docs/examples/dynamic_fanout_fanin.md
@@ -1,4 +1,6 @@
-# Dynamic fanout with fanin
+# Dynamic Fanout Fanin
+
+
 
 ```python
 from hera import Parameter, Task, ValueFrom, Workflow

--- a/docs/examples/dynamic_fanout_fanin_artifacts.md
+++ b/docs/examples/dynamic_fanout_fanin_artifacts.md
@@ -1,4 +1,4 @@
-# Dynamic fanout and fanin with artifacts
+# Dynamic Fanout Fanin Artifacts
 
 Example derived from: https://medium.com/@corvin/dynamic-fan-out-and-fan-in-in-argo-workflows-d731e144e2fd
 

--- a/docs/examples/env.md
+++ b/docs/examples/env.md
@@ -1,4 +1,4 @@
-# Dynamic environment variables
+# Env
 
 This example showcases how Hera can dynamically set environmental variables
 

--- a/docs/examples/existing_volume.md
+++ b/docs/examples/existing_volume.md
@@ -1,4 +1,4 @@
-# Existing volume
+# Existing Volume
 
 This example showcases how Hera supports mounting existing volumes. These volumes are expected to already be
 provisioned and available as a persistent volume claim in the K8S cluster where Argo runs.
@@ -22,5 +22,4 @@ with Workflow("existing-volume") as w:
     )
 
 w.create()
-
 ```

--- a/docs/examples/gitops.md
+++ b/docs/examples/gitops.md
@@ -1,4 +1,4 @@
-# Sample GitOps pattern
+# Gitops
 
 This example showcases the hello world example of Hera in a GitOps style. The workflow gets a global parameter set
 called `msg`. This parameter has neither a `value` nor a `value_from` set. This supports the generation of a workflow
@@ -6,8 +6,6 @@ YAML file that has the full definition and supports submission via `argo submit 
 parameterizes the workflow global parameter called `msg` to have a `value` of `hello`. This `hello` is then passed to
 the `Task` via the global parameter `w.get_parameter('msg')`, which sets the `'{{workflow.parameters.msg}}'` on the
 task parameter definition.
-
-## Workflow definition (Python)
 
 ```python
 from hera import Parameter, Task, Workflow
@@ -22,10 +20,6 @@ with Workflow("hera-gitops-say", parameters=[Parameter('msg')]) as w:
 
 with open('hello.yaml', 'w') as f:
     f.write(w.to_yaml())
-```
 
-## GitOps style/local submission
-
-```shell
-argo submit hello.yaml -p msg="hello"
+# the above is followed up by issuing `argo submit hello.yaml -p msg="hello"`
 ```

--- a/docs/examples/global_host.md
+++ b/docs/examples/global_host.md
@@ -1,6 +1,6 @@
-# Global host
+# Global Host
 
-This example showcases how to set an Argo Workflows host and token at a global level.
+This example showcases how to set an Argo Workflows host and token at a global level
 
 ```python
 from hera import Task, Workflow, set_global_host, set_global_token

--- a/docs/examples/global_parameters.md
+++ b/docs/examples/global_parameters.md
@@ -1,4 +1,6 @@
-# Global parameters
+# Global Parameters
+
+
 
 ```python
 from hera import Parameter, Task, Workflow
@@ -12,5 +14,4 @@ with Workflow("global-parameters", parameters=[Parameter("v", "42")]) as w:
     Task("t", foo, inputs=[w.get_parameter("v")])
 
 w.create()
-
 ```

--- a/docs/examples/gpu.md
+++ b/docs/examples/gpu.md
@@ -1,4 +1,4 @@
-# GPU
+# Gpu
 
 This task showcases how clients can request a particular number of GPUs to be available for a task and the specific
 type of GPU to request. The task uses the Horovod image as it provides Python and NVIDIA SMI.

--- a/docs/examples/hello_hera.md
+++ b/docs/examples/hello_hera.md
@@ -1,9 +1,8 @@
 # Hello Hera
 
-This example showcases the hello world example of Hera.
+This example showcases the hello world example of Hera
 
 ```python
-
 from hera import Task, Workflow
 
 
@@ -16,5 +15,4 @@ with Workflow("hello-hera") as w:
     Task("t", hello)
 
 w.create()
-
 ```

--- a/docs/examples/hello_hera_cron.md
+++ b/docs/examples/hello_hera_cron.md
@@ -1,6 +1,6 @@
 # Hello Hera Cron
 
-This example showcases the cron hello world example of Hera.
+This example showcases the cron hello world example of Hera
 
 ```python
 from hera import CronWorkflow, Task

--- a/docs/examples/input_output.md
+++ b/docs/examples/input_output.md
@@ -1,4 +1,6 @@
-# Input/Output
+# Input Output
+
+
 
 ```python
 from hera import Parameter, Task, ValueFrom, Workflow

--- a/docs/examples/internal_wrapper.md
+++ b/docs/examples/internal_wrapper.md
@@ -1,10 +1,10 @@
-# Internal wrapper
+# Internal Wrapper
 
 This example showcases how clients can simplify their workflow submission process by introducing some abstractions on
 top of Hera to support consistency in submission across users, teams, etc.
 
-````python
-from typing import Callable, List, Optional, Union
+```python
+from typing import Any, Callable, List, Optional, Union
 
 from hera import (
     ExistingVolume,
@@ -27,7 +27,7 @@ def generate_token() -> str:
 
 
 class MyWorkflowService(WorkflowService):
-    """Internal WorkflowService wrapper around Hera's WorkflowService to support consistency in auth token generation"""
+    """Internal service wrapper around Hera's WorkflowService to support consistency in auth token generation"""
 
     def __init__(self, host: str = "https://my-argo-domain.com", token: str = generate_token()):
         super(MyWorkflowService, self).__init__(host=host, token=token, namespace="my-default-k8s-namespace")
@@ -79,4 +79,4 @@ def example():
         MyTask("t", lambda: print(42))
 
     w.create()
-````
+```

--- a/docs/examples/k8s_sa.md
+++ b/docs/examples/k8s_sa.md
@@ -1,6 +1,6 @@
-# K8S service account token
+# K8S Sa
 
-This example showcases the hello world example of Hera using kubernetes user token.
+This example showcases the hello world example of Hera using kubernetes user token
 
 ```python
 import base64

--- a/docs/examples/linear.md
+++ b/docs/examples/linear.md
@@ -1,6 +1,6 @@
 # Linear
 
-This example showcases how to structure a linear chain of tasks.
+This example showcases how to structure a linear chain of tasks
 
 ```python
 from hera import Task, Workflow
@@ -27,5 +27,4 @@ with Workflow("linear") as w:
     Task("t1", task_1) >> Task("t2", task_2) >> Task("t3", task_3) >> Task("t4", task_4)
 
 w.create()
-
 ```

--- a/docs/examples/lint.md
+++ b/docs/examples/lint.md
@@ -1,9 +1,9 @@
-# Linting
+# Lint
 
-This example showcases how to lint workflows supported by Hera.
+This example showcases how to lint workflows supported by Hera
 
 ```python
-from hera import CronWorkflow, Workflow, WorkflowTemplate, Task
+from hera import CronWorkflow, Task, Workflow, WorkflowTemplate
 
 
 def say(msg: str) -> None:

--- a/docs/examples/memoize.md
+++ b/docs/examples/memoize.md
@@ -1,5 +1,7 @@
 # Memoize
 
+
+
 ```python
 from hera import Memoize, Parameter, Task, ValueFrom, Workflow
 
@@ -15,10 +17,9 @@ def consume(value):
 
 # assumes you used `hera.set_global_token` and `hera.set_global_host` so that the workflow can be submitted
 with Workflow("memoize") as w:
-    g = Task("g", generate, outputs=[Parameter("out", value_from=ValueFrom(path="/out"))])
-    c = Task("c", consume, inputs=[g.get_parameter("out")], memoize=Memoize("value", "memoize", "c"))
+    g = Task("g", generate, outputs=[Parameter("value", value_from=ValueFrom(path="/out"))])
+    c = Task("c", consume, inputs=[g.get_parameter("value")], memoize=Memoize("value", "memoize", "c"))
     g >> c
 
 w.create()
-
 ```

--- a/docs/examples/metrics.md
+++ b/docs/examples/metrics.md
@@ -1,7 +1,7 @@
-# Prometheus metrics
+# Metrics
 
 This example showcases the classic diamond workflow along with metrics used to track the workflow. For information on
-how to use metrics and what metrics are accessible out of the box with Argo see: 
+how to use metrics and what metrics are accessible out of the box with Argo see:
 https://argoproj.github.io/argo-workflows/metrics/#grafana-dashboard-for-argo-controller-metrics
 
 ```python
@@ -22,5 +22,4 @@ with Workflow("diamond", metrics=[Metric("w", "help-w")]) as w:
     a >> [b, c] >> d
 
 w.create()
-
 ```

--- a/docs/examples/multiple_dependencies.md
+++ b/docs/examples/multiple_dependencies.md
@@ -1,6 +1,6 @@
-# Multiple dependencies
+# Multiple Dependencies
 
-This simple example showcases how to set a single task as a dependency of multiple other tasks.
+This simple example showcases how to set a single task as a dependency of multiple other tasks
 
 ```python
 from hera import Task, Workflow
@@ -17,5 +17,4 @@ def hello():
 with Workflow("multiple-dependencies") as w:
     Task("hello-world", hello) >> [Task("foo1", foo), Task("foo2", foo), Task("foo3", foo)]
 w.create()
-
 ```

--- a/docs/examples/parallel_dag.md
+++ b/docs/examples/parallel_dag.md
@@ -1,4 +1,4 @@
-# Parallel DAG
+# Parallel Dag
 
 This example showcases how one can schedule a workflow with a parallel DAG task through Hera
 
@@ -32,5 +32,4 @@ with Workflow("parallel-dag") as wf:
     t1 >> t2
 
 wf.create()
-
 ```

--- a/docs/examples/parallel_diamonds.md
+++ b/docs/examples/parallel_diamonds.md
@@ -1,4 +1,4 @@
-# Parallel diamonds
+# Parallel Diamonds
 
 This example showcases how one can schedule a diamond structure with parallel processing through Hera
 
@@ -35,5 +35,4 @@ with Workflow("parallel-diamonds") as w:
     )
 
 w.create()
-
 ```

--- a/docs/examples/parameters.md
+++ b/docs/examples/parameters.md
@@ -3,7 +3,7 @@
 This example showcases how one can set parameters on Hera tasks
 
 ```python
-from hera import Task, Workflow, set_global_host, set_global_token
+from hera import Task, Workflow
 
 
 def hello(a: str, b: int, c: dict):

--- a/docs/examples/post_init_hooks.md
+++ b/docs/examples/post_init_hooks.md
@@ -1,8 +1,7 @@
-# Post init hooks
+# Post Init Hooks
 
 This example showcases how to register two global workflow hooks, which will modify the workflow post-init.
-
-See `hera.global_config.WorkflowHook` for the `Protocol` specification of the hook implementation/type signature.
+See `hera.global_config.WorkflowHook` for the `Protocol` specification of the hook implementation/type signature
 
 ```python
 from hera import GlobalConfig, Task, Workflow

--- a/docs/examples/retry.md
+++ b/docs/examples/retry.md
@@ -21,5 +21,4 @@ with Workflow("retry") as w:
     Task("fail", random_fail, retry_strategy=RetryStrategy(backoff=Backoff(duration="5", max_duration="60")))
 
 w.create()
-
 ```

--- a/docs/examples/secret_volume.md
+++ b/docs/examples/secret_volume.md
@@ -1,4 +1,4 @@
-# Secret volume
+# Secret Volume
 
 This example showcases how clients can mount secrets inside a task
 
@@ -20,5 +20,4 @@ with Workflow("secret-volume") as w:
     Task("use_secret", use_secret, volumes=[SecretVolume(secret_name="secret-file", mount_path="/secret/")])
 
 w.create()
-
 ```

--- a/docs/examples/sidecar.md
+++ b/docs/examples/sidecar.md
@@ -12,7 +12,9 @@ with Workflow("sidecar-", generate_name=True) as w:
         image="alpine:latest",
         command=["sh", "-c"],
         args=[
-            "apk update && apk add curl && until curl -XPOST 'http://127.0.0.1:8086/query' --data-urlencode 'q=CREATE DATABASE mydb' ; do sleep .5; done && for i in $(seq 1 20); do curl -XPOST 'http://127.0.0.1:8086/write?db=mydb' -d \"cpu,host=server01,region=uswest load=$i\" ; sleep .5 ; done"
+            "apk update && apk add curl && until curl -XPOST 'http://127.0.0.1:8086/query' --data-urlencode "
+            "'q=CREATE DATABASE mydb' ; do sleep .5; done && for i in $(seq 1 20); do curl -XPOST "
+            "'http://127.0.0.1:8086/write?db=mydb' -d \"cpu,host=server01,region=uswest load=$i\" ; sleep .5 ; done"
         ],
         sidecars=[Sidecar("influxdb", image="influxdb:1.2", command=["influxd"])],
     )

--- a/docs/examples/sidecar_dind.md
+++ b/docs/examples/sidecar_dind.md
@@ -1,6 +1,6 @@
-# Docker in Docker sidecar container
+# Sidecar Dind
 
-This example showcases how one can run Docker in Docker with a sidecar container with Hera.
+This example showcases how one can run Docker in Docker with a sidecar container with Hera
 
 ```python
 from hera import Env, Sidecar, Task, TaskSecurityContext, Workflow

--- a/docs/examples/sidecar_nginx.md
+++ b/docs/examples/sidecar_nginx.md
@@ -1,6 +1,6 @@
-# NGINX sidecar
+# Sidecar Nginx
 
-This example showcases how one can run an Nginx sidecar container with Hera.
+This example showcases how one can run an Nginx sidecar container with Hera
 
 ```python
 from hera import Sidecar, Task, Workflow

--- a/docs/examples/suspend.md
+++ b/docs/examples/suspend.md
@@ -1,6 +1,6 @@
 # Suspend
 
-This example showcases how to use a `suspend` template with Hera.
+This example showcases how to use a `suspend` template with Hera
 
 ```python
 from hera import Suspend, Task, Workflow

--- a/docs/examples/task_exit_handler.md
+++ b/docs/examples/task_exit_handler.md
@@ -1,4 +1,6 @@
-# Task exit handler
+# Task Exit Handler
+
+
 
 ```python
 from hera import Task, Workflow

--- a/docs/examples/volume.md
+++ b/docs/examples/volume.md
@@ -30,5 +30,4 @@ with Workflow(
     Task("do", do, volumes=[Volume(size="50Gi", mount_path="/vol")])
 
 w.create()
-
 ```

--- a/docs/examples/with_sequence.md
+++ b/docs/examples/with_sequence.md
@@ -1,4 +1,4 @@
-# With sequence
+# With Sequence
 
 This example showcases how to generate and parallelize generated sequences
 
@@ -23,5 +23,4 @@ with Workflow("with-sequence-example") as w:
     t1 >> [t2, t3]
 
 w.create()
-
 ```

--- a/docs/examples/workflow_on_exit.md
+++ b/docs/examples/workflow_on_exit.md
@@ -1,4 +1,6 @@
-# Workflow on exit
+# Workflow On Exit
+
+
 
 ```python
 from hera import DAG, Task, Workflow, WorkflowStatus
@@ -23,5 +25,4 @@ with Workflow("on-exit") as w:
 
     w.on_exit(exit_procedure)
 w.create()
-
 ```

--- a/docs/examples/workflow_template_global_parameters.md
+++ b/docs/examples/workflow_template_global_parameters.md
@@ -1,0 +1,18 @@
+# Workflow Template Global Parameters
+
+
+
+```python
+from hera import Parameter, Task, WorkflowTemplate
+
+
+def foo(v):
+    print(v)
+
+
+# assumes you used `hera.set_global_token` and `hera.set_global_host` so that the workflow can be submitted
+with WorkflowTemplate("global-parameters", parameters=[Parameter("v", "42")]) as w:
+    Task("t", foo, inputs=[w.get_parameter("v")])
+
+w.create()
+```

--- a/docs/examples/workflow_with_custom_image.md
+++ b/docs/examples/workflow_with_custom_image.md
@@ -1,4 +1,4 @@
-# Workflow with custom image
+# Workflow With Custom Image
 
 This example showcases how to run a container, rather than a Python, function, as the payload of a task in Hera
 

--- a/docs/examples/workflow_with_template_ref.md
+++ b/docs/examples/workflow_with_template_ref.md
@@ -1,4 +1,6 @@
-# Workflow with template ref
+# Workflow With Template Ref
+
+
 
 ```python
 from hera import Task, TemplateRef, Workflow
@@ -8,5 +10,4 @@ with Workflow("workflow-with-template-ref") as w:
     Task("coin-flip", template_ref=TemplateRef(name="hera-workflow-templates", template="coin-flip"))
 
 w.create()
-
 ```

--- a/docs/generate.py
+++ b/docs/generate.py
@@ -1,0 +1,39 @@
+import re
+from pathlib import Path
+
+# This code reads the contents at the path which is a python file,
+# extracts the python docstring at the top using a regex and then
+# outputs a markdown file with the same name as a python file without the .py extension and
+# with a .md extension. The markdown file contains the docstring
+# as the initial text block and contains the rest of the python file
+# as a python code block. The header of the markdown file is
+# generated using the name of the file but converted from snake case
+# to sentence case.
+def generate_markdown(path: Path):
+    contents = path.read_text()
+    match = re.search(r'^"""(.*?)"""', contents, re.DOTALL)
+    if match:
+        docstring = match.group(1)
+    else:
+        docstring = ""
+    # remove the module docstring at the top of the python file using regex
+    contents = re.sub(r'^(""".*?""")', "", contents, 1, re.DOTALL)
+    title = path.stem.replace("_", " ").title()
+    contents = f"""# {title}
+
+{docstring.strip()}
+
+```python
+{contents.strip()}
+```
+"""
+    (Path("examples")/ path.stem).with_suffix(".md").write_text(contents)
+
+
+def main():
+    # we need to go through each path and generate its markdown
+    for path in Path("../examples").glob("*.py"):
+        generate_markdown(path)
+
+if __name__ == "__main__":
+    main()

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,60 +18,11 @@ Welcome to Hera's documentation!
    expr
 
 .. toctree::
+   :glob:
    :maxdepth: 2
    :caption: Examples
 
-   examples/any_success_all_fail
-   examples/artifact
-   examples/artifact_with_fanout
-   examples/coinflip
-   examples/complex_expr
-   examples/conditional
-   examples/container
-   examples/custom_script
-   examples/daemon
-   examples/default_param_overwrite
-   examples/diamond
-   examples/dynamic_fanout
-   examples/dynamic_fanout_container
-   examples/dynamic_fanout_fanin
-   examples/dynamic_fanout_fanin_artifacts
-   examples/env
-   examples/existing_volume
-   examples/gitops
-   examples/global_host
-   examples/global_parameters
-   examples/gpu
-   examples/hello_hera
-   examples/hello_hera_cron
-   examples/input_output
-   examples/internal_wrapper
-   examples/k8s_sa
-   examples/linear
-   examples/lint
-   examples/memoize
-   examples/metrics
-   examples/multiple_dependencies
-   examples/parallel_dag
-   examples/parallel_diamonds
-   examples/parameters
-   examples/post_init_hooks
-   examples/retry
-   examples/secret_volume
-   examples/sidecar
-   examples/sidecar_dind
-   examples/sidecar_nginx
-   examples/suspend
-   examples/task_exit_handler
-   examples/volume
-   examples/with_sequence
-   examples/workflow_on_exit
-   examples/workflow_template
-   examples/workflow_template_global_parameter
-   examples/workflow_with_custom_image
-   examples/workflow_with_template_ref
-
-
+   examples/*
 
 Indices and tables
 ==================

--- a/examples/daemon.py
+++ b/examples/daemon.py
@@ -1,7 +1,7 @@
-# Enablement of https://argoproj.github.io/argo-workflows/variables/
-# This example creates two tasks, one of the Tasks is a deamond task and its IP address is shared with the second task
-# The daemoned task operates as server, serving an example payload, with the second task operating as a client, making
-# http requests to the server
+"""Enablement of https://argoproj.github.io/argo-workflows/variables/
+This example creates two tasks, one of the Tasks is a deamond task and its IP address is shared with the second task
+The daemoned task operates as server, serving an example payload, with the second task operating as a client, making
+http requests to the server."""
 
 from hera import Env, Task, Workflow
 

--- a/examples/dynamic_fanout_fanin_artifacts.py
+++ b/examples/dynamic_fanout_fanin_artifacts.py
@@ -1,4 +1,4 @@
-# Example derived from: https://medium.com/@corvin/dynamic-fan-out-and-fan-in-in-argo-workflows-d731e144e2fd
+"""Example derived from: https://medium.com/@corvin/dynamic-fan-out-and-fan-in-in-argo-workflows-d731e144e2fd"""
 from hera import Archive, GCSArtifact, Task, Workflow
 
 

--- a/examples/post_init_hooks.py
+++ b/examples/post_init_hooks.py
@@ -1,5 +1,5 @@
-# This example showcases how to register two global workflow hooks, which will modify the workflow post-init.
-# See `hera.global_config.WorkflowHook` for the `Protocol` specification of the hook implementation/type signature
+"""This example showcases how to register two global workflow hooks, which will modify the workflow post-init.
+See `hera.global_config.WorkflowHook` for the `Protocol` specification of the hook implementation/type signature"""
 
 from hera import GlobalConfig, Task, Workflow
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39,310},coverage,lint,typecheck,format
+envlist = py{37,38,39,310},coverage,lint,typecheck,format,examples
 isolated_build = true
 
 [pytest]
@@ -73,3 +73,11 @@ whitelist_externals = poetry
 commands =
     poetry install
     poetry run mypy --show-traceback --namespace-packages --explicit-package-bases -p hera
+
+[testenv:examples]
+skipsdist = True
+changedir = docs
+whitelist_externals = git
+commands =
+    python generate.py
+    git diff --exit-code -- examples

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39,310},coverage,lint,typecheck,format,examples
+envlist = py{37,38,39,310},coverage,lint,typecheck,format,check-examples,generate-examples
 isolated_build = true
 
 [pytest]
@@ -74,7 +74,14 @@ commands =
     poetry install
     poetry run mypy --show-traceback --namespace-packages --explicit-package-bases -p hera
 
-[testenv:examples]
+[testenv:generate-examples]
+skipsdist = True
+changedir = docs
+whitelist_externals = git
+commands =
+    python generate.py
+
+[testenv:check-examples]
 skipsdist = True
 changedir = docs
 whitelist_externals = git


### PR DESCRIPTION
Signed-off-by: Sambhav Kothari <skothari44@bloomberg.net>

Fixes #349

This ensures that the doc's examples folder is in sync with the examples scripts folder.

@flaviuvadan also automatically generated some missing example files and updated some existing ones which had drifted.