### PR TITLE
Fix name validation, add support for generate_name

### DIFF
--- a/src/hera/validators.py
+++ b/src/hera/validators.py
@@ -10,11 +10,22 @@ def validate_name(name: str, max_length: Optional[int] = None, generate_name: bo
     ----------
     name: str
         The name which should be validated.
+    max_length: Optional[int] = None
+        Specify a maximum length of the name.
+        Example: Kubernetes labels have a maximum length of 63 characters.
+    generate_name: bool = False
+        Whether the provided name is to be used as a prefix for name generation.
+        If set, name is allowed to end in a single dot (.) or any number of hyphens (-).
 
     Raises
     ------
     ValueError
         When the name is invalid according to specifications.
+
+    Notes
+    -----
+    Official doc on object names in Kubernetes:
+    https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
     """
     if max_length and len(name) > max_length:
         raise ValueError(f"Name is too long. Max length: {max_length}, found: {len(name)}")

--- a/src/hera/validators.py
+++ b/src/hera/validators.py
@@ -31,6 +31,8 @@ def validate_name(name: str, max_length: Optional[int] = None, generate_name: bo
         raise ValueError(f"Name is too long. Max length: {max_length}, found: {len(name)}")
     if "_" in name:
         raise ValueError("Name cannot include an underscore")
+    if not generate_name and name.endswith((".", "-")):
+        raise ValueError("Name cannot end with '.' nor '-', unless it is used as a prefix for name generation")
 
     pattern = r"[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"
     if generate_name:

--- a/src/hera/validators.py
+++ b/src/hera/validators.py
@@ -22,7 +22,7 @@ def validate_name(name: str, max_length: Optional[int] = None) -> str:
         raise ValueError("Name cannot include an underscore")
 
     pattern = r"[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"
-    match_obj = re.match(pattern, name)
+    match_obj = re.fullmatch(pattern, name)
     if not match_obj:
         raise ValueError(f"Name is invalid: '{name}'. Regex used for validation is {pattern}")
     return name

--- a/src/hera/validators.py
+++ b/src/hera/validators.py
@@ -3,7 +3,7 @@ import re
 from typing import Optional
 
 
-def validate_name(name: str, max_length: Optional[int] = None) -> str:
+def validate_name(name: str, max_length: Optional[int] = None, generate_name: bool = False) -> str:
     """Validates a name according to standard argo/kubernetes limitations
 
     Parameters
@@ -22,6 +22,8 @@ def validate_name(name: str, max_length: Optional[int] = None) -> str:
         raise ValueError("Name cannot include an underscore")
 
     pattern = r"[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"
+    if generate_name:
+        pattern += r"(\.?|-*)"
     match_obj = re.fullmatch(pattern, name)
     if not match_obj:
         raise ValueError(f"Name is invalid: '{name}'. Regex used for validation is {pattern}")

--- a/src/hera/validators.py
+++ b/src/hera/validators.py
@@ -21,7 +21,7 @@ def validate_name(name: str, max_length: Optional[int] = None) -> str:
     if "_" in name:
         raise ValueError("Name cannot include an underscore")
 
-    pattern = r"[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"
+    pattern = r"[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"
     match_obj = re.fullmatch(pattern, name)
     if not match_obj:
         raise ValueError(f"Name is invalid: '{name}'. Regex used for validation is {pattern}")

--- a/src/hera/workflow.py
+++ b/src/hera/workflow.py
@@ -128,7 +128,7 @@ class Workflow:
         metrics: Optional[Union[Metric, List[Metric], Metrics]] = None,
     ):
         self.name = validate_name(name, generate_name=generate_name)
-        dag_name = self.name if dag_name is None else dag_name
+        dag_name = self.name.rstrip("-.") if dag_name is None else dag_name
         self.dag = DAG(dag_name) if dag is None else dag
         self._service = service
         self.parallelism = parallelism

--- a/src/hera/workflow.py
+++ b/src/hera/workflow.py
@@ -127,7 +127,7 @@ class Workflow:
         active_deadline_seconds: Optional[int] = None,
         metrics: Optional[Union[Metric, List[Metric], Metrics]] = None,
     ):
-        self.name = validate_name(name)
+        self.name = validate_name(name, generate_name=generate_name)
         dag_name = self.name if dag_name is None else dag_name
         self.dag = DAG(dag_name) if dag is None else dag
         self._service = service

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -16,10 +16,11 @@ def test_validate_name():
         validate_name("TEST")
     assert (
         str(e.value) == "Name is invalid: 'TEST'. Regex used for validation is "
-        "[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"
+        r"[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"
     )
     with pytest.raises(ValueError):
         validate_name("test-")
+    validate_name("test.a")
 
 
 def test_storage_validation_passes():

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -21,6 +21,14 @@ def test_validate_name():
     with pytest.raises(ValueError):
         validate_name("test-")
     validate_name("test.a")
+    validate_name("test-", generate_name=True)
+    validate_name("test.", generate_name=True)
+    with pytest.raises(ValueError) as e:
+        validate_name("test.-", generate_name=True)
+    assert (
+        str(e.value) == "Name is invalid: 'test.-'. Regex used for validation is "
+        r"[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\.?|-*)"
+    )
 
 
 def test_storage_validation_passes():

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -18,6 +18,8 @@ def test_validate_name():
         str(e.value) == "Name is invalid: 'TEST'. Regex used for validation is "
         "[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"
     )
+    with pytest.raises(ValueError):
+        validate_name("test-")
 
 
 def test_storage_validation_passes():

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -24,6 +24,12 @@ def test_validate_name():
     validate_name("test-", generate_name=True)
     validate_name("test.", generate_name=True)
     with pytest.raises(ValueError) as e:
+        validate_name("test-")
+    assert str(e.value) == "Name cannot end with '.' nor '-', unless it is used as a prefix for name generation"
+    with pytest.raises(ValueError) as e:
+        validate_name("test.")
+    assert str(e.value) == "Name cannot end with '.' nor '-', unless it is used as a prefix for name generation"
+    with pytest.raises(ValueError) as e:
         validate_name("test.-", generate_name=True)
     assert (
         str(e.value) == "Name is invalid: 'test.-'. Regex used for validation is "


### PR DESCRIPTION
While browsing through the code, I spotted an issue in `validate_name` in that it uses [`re.match`](https://docs.python.org/3/library/re.html#re.match) (match the beginning of the string) rather than [`re.fullmatch`](https://docs.python.org/3/library/re.html#re.fullmatch) (match the whole string). One thing led to another, and I found and fixed a couple more bugs, and added a new parameter for proper validation of `metadata.generateName`.

Names in k8s cannot end in hyphen "-" or period ".", however the same is a valid choice for `metadata.generateName`. I have extended `validate_name` with an optional `generate_name` parameter to support this, synchronized with the identical parameter of `workflow.__init__`.

### Changes
- Validate entire name in `validate_name`, not only the beginning of the string
  - Without this, the invalid name `"test#"` would unexpectedly pass validation.
- Fix quoting of "." in pattern used in `validate_name`
  - Without this, the invalid name `r"test\@"` would unexpectedly pass validation
- Add a new `generate_name` boolean parameter, default to `False`; if `True`, a `name` ending in a single period "." or any number of hyphens "-" will pass validation, as alphanumeric characters are expected to be appended in the final name
  - Without this, the valid generate name `"test-"` would unexpectedly fail validation
- Strip trailing "-" and "." characters when workflow name is reused for an unnamed dag
  - Without this, the valid generate name `"test-"` would result in a validation error if the dag is not named explicitly