### PR TITLE
Ephemeral storage

### DIFF
--- a/src/hera/resources.py
+++ b/src/hera/resources.py
@@ -40,6 +40,10 @@ class Resources:
         The amount of memory to request.
     memory_limit: Optional[str] = None
         The memory limit of the pod.
+    ephemeral_request: Optional[str] = None
+        The amount of ephemeral storage to request.
+    ephemeral_limit: Optional[str] = None
+        The emphemeral storage limit of the pod.
     gpus: Optional[int] = None
         The number of GPUs to request.
     gpu_flag: Optional[str] = "nvidia.com/gpu"
@@ -52,6 +56,8 @@ class Resources:
     cpu_limit: Optional[Union[float, int, str]] = None
     memory_request: Optional[str] = None
     memory_limit: Optional[str] = None
+    ephemeral_request: Optional[str] = None
+    ephemeral_limit: Optional[str] = None
     gpus: Optional[int] = None
     gpu_flag: Optional[str] = "nvidia.com/gpu"
     custom_resources: Optional[Dict] = None
@@ -61,8 +67,14 @@ class Resources:
             validate_storage_units(self.memory_request)
         if self.memory_limit:
             validate_storage_units(self.memory_limit)
-        # TODO: add validation for CPU units if str
 
+        if self.ephemeral_request:
+            validate_storage_units(self.ephemeral_request)
+        if self.ephemeral_limit:
+            validate_storage_units(self.ephemeral_limit)
+
+
+        # TODO: add validation for CPU units if str
         if self.cpu_limit is not None and isinstance(self.cpu_limit, int):
             assert self.cpu_limit >= 0, "CPU limit must be positive"
         if self.cpu_request is not None and isinstance(self.cpu_request, int):
@@ -90,6 +102,12 @@ class Resources:
 
         if self.memory_request is not None:
             resources = _merge_dicts(resources, dict(requests=dict(memory=self.memory_request)))
+
+        if self.ephemeral_limit is not None:
+            resources = _merge_dicts(resources, dict(limits=dict(memory=self.ephemeral_limit)))
+
+        if self.ephemeral_request is not None:
+            resources = _merge_dicts(resources, dict(requests=dict(memory=self.ephemeral_request)))
 
         if self.gpus is not None:
             resources = _merge_dicts(resources, dict(requests={self.gpu_flag: str(self.gpus)}))

--- a/src/hera/resources.py
+++ b/src/hera/resources.py
@@ -73,7 +73,6 @@ class Resources:
         if self.ephemeral_limit:
             validate_storage_units(self.ephemeral_limit)
 
-
         # TODO: add validation for CPU units if str
         if self.cpu_limit is not None and isinstance(self.cpu_limit, int):
             assert self.cpu_limit >= 0, "CPU limit must be positive"
@@ -104,10 +103,10 @@ class Resources:
             resources = _merge_dicts(resources, dict(requests=dict(memory=self.memory_request)))
 
         if self.ephemeral_limit is not None:
-            resources = _merge_dicts(resources, dict(limits=dict(memory=self.ephemeral_limit)))
+            resources = _merge_dicts(resources, dict(limits={"ephemeral-storage": self.ephemeral_limit}))
 
         if self.ephemeral_request is not None:
-            resources = _merge_dicts(resources, dict(requests=dict(memory=self.ephemeral_request)))
+            resources = _merge_dicts(resources, dict(requests={"ephemeral-storage": self.ephemeral_request}))
 
         if self.gpus is not None:
             resources = _merge_dicts(resources, dict(requests={self.gpu_flag: str(self.gpus)}))

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -22,6 +22,12 @@ class TestResources:
         with pytest.raises(ValueError):
             Resources(memory_limit="4")
 
+    def test_init_raises_on_invalid_eph(self):
+        with pytest.raises(ValueError):
+            Resources(ephemeral_request="3m")
+        with pytest.raises(ValueError):
+            Resources(ephemeral_limit="2m")
+
     def test_init_raises_on_invalid_cpu(self):
         with pytest.raises(AssertionError):
             Resources(cpu_limit=-1)
@@ -34,12 +40,16 @@ class TestResources:
             cpu_limit=2,
             memory_request="2Gi",
             memory_limit="3Gi",
+            ephemeral_request="2Mi",
+            ephemeral_limit="3Mi",
             gpus=1,
         )
         assert r.cpu_request == 1
         assert r.cpu_limit == 2
         assert r.memory_request == "2Gi"
         assert r.memory_limit == "3Gi"
+        assert r.ephemeral_request == "2Mi"
+        assert r.ephemeral_limit == "3Mi"
         assert r.gpus == 1
 
     def test_max_set_to_min_if_max_not_specified_with_overwrite(self):
@@ -48,17 +58,28 @@ class TestResources:
         assert r.memory_request == r.memory_limit == "4Gi"
 
     def test_max_not_set_to_min_if_max_not_specified_with_no_overwrite(self):
-        r = Resources(cpu_request=1, memory_request="4Gi")
+        r = Resources(cpu_request=1, memory_request="4Gi", ephemeral_request="3Mi")
         assert r.cpu_request == 1
         assert r.cpu_limit is None
         assert r.memory_request == "4Gi"
         assert r.memory_limit is None
+        assert r.ephemeral_request == "3Mi"
+        assert r.ephemeral_limit is None
 
     def test_built_resources_contain_expected_fields(self):
-        r = Resources(cpu_request=1, memory_request="4Gi", cpu_limit=2, memory_limit="8Gi").build()
+        r = Resources(
+            cpu_request=1,
+            memory_request="4Gi",
+            ephemeral_request="3Mi",
+            cpu_limit=2,
+            memory_limit="8Gi",
+            ephemeral_limit="5Mi",
+        ).build()
         assert hasattr(r, "limits")
         assert "cpu" in r.limits
         assert "memory" in r.limits
+        assert "ephemeral-storage" in r.limits
         assert hasattr(r, "requests")
         assert "cpu" in r.requests
         assert "memory" in r.requests
+        assert "ephemeral-storage" in r.requests

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -23,9 +23,9 @@ class TestResources:
             Resources(memory_limit="4")
 
     def test_init_raises_on_invalid_eph(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(AssertionError):
             Resources(ephemeral_request="3m")
-        with pytest.raises(ValueError):
+        with pytest.raises(AssertionError):
             Resources(ephemeral_limit="2m")
 
     def test_init_raises_on_invalid_cpu(self):


### PR DESCRIPTION
Kubernetes now supports an 'ephemeral-storage' spec on resources, which can allow pods some amount of specified memory for logging and the such. This adds the same named parameter to Hera.