### PR TITLE
Simplify Task and Workflow script comparisons

### DIFF
--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1,4 +1,5 @@
 import json
+from textwrap import dedent
 from unittest import mock
 
 import pytest
@@ -99,34 +100,44 @@ class TestTask:
     def test_param_script_portion_adds_formatted_json_calls(self, op):
         t = Task("t", op, [{"a": 1}])
         script = t._get_param_script_portion()
-        assert (
-            script == "import json\n"
-            "try: a = json.loads(r'''{{inputs.parameters.a}}''')\n"
-            "except: a = r'''{{inputs.parameters.a}}'''\n"
+        assert script == dedent(
+            """\
+            import json
+            try: a = json.loads(r'''{{inputs.parameters.a}}''')
+            except: a = r'''{{inputs.parameters.a}}'''
+            """
         )
 
     def test_script_getter_returns_expected_string(self, op, typed_op):
         t = Task("t", op, [{"a": 1}])
         script = t._get_script()
-        assert (
-            script == "import os\nimport sys\nsys.path.append(os.getcwd())\n"
-            "import json\n"
-            "try: a = json.loads(r'''{{inputs.parameters.a}}''')\n"
-            "except: a = r'''{{inputs.parameters.a}}'''\n"
-            "\n"
-            "print(a)\n"
+        assert script == dedent(
+            """\
+            import os
+            import sys
+            sys.path.append(os.getcwd())
+            import json
+            try: a = json.loads(r'''{{inputs.parameters.a}}''')
+            except: a = r'''{{inputs.parameters.a}}'''
+
+            print(a)
+            """
         )
 
         t = Task("t", typed_op, [{"a": 1}])
         script = t._get_script()
-        assert (
-            script == "import os\nimport sys\nsys.path.append(os.getcwd())\n"
-            "import json\n"
-            "try: a = json.loads(r'''{{inputs.parameters.a}}''')\n"
-            "except: a = r'''{{inputs.parameters.a}}'''\n"
-            "\n"
-            "print(a)\n"
-            'return [{"a": (a, a)}]\n'
+        assert script == dedent(
+            """\
+            import os
+            import sys
+            sys.path.append(os.getcwd())
+            import json
+            try: a = json.loads(r'''{{inputs.parameters.a}}''')
+            except: a = r'''{{inputs.parameters.a}}'''
+
+            print(a)
+            return [{"a": (a, a)}]
+            """
         )
 
     def test_script_getter_parses_multi_line_function(self, long_op):
@@ -144,23 +155,26 @@ class TestTask:
             ],
         )
 
-        expected_script = """import os
-import sys
-sys.path.append(os.getcwd())
-import json
-try: very_long_parameter_name = json.loads(r'''{{inputs.parameters.very_long_parameter_name}}''')
-except: very_long_parameter_name = r'''{{inputs.parameters.very_long_parameter_name}}'''
-try: very_very_long_parameter_name = json.loads(r'''{{inputs.parameters.very_very_long_parameter_name}}''')
-except: very_very_long_parameter_name = r'''{{inputs.parameters.very_very_long_parameter_name}}'''
-try: very_very_very_long_parameter_name = json.loads(r'''{{inputs.parameters.very_very_very_long_parameter_name}}''')
-except: very_very_very_long_parameter_name = r'''{{inputs.parameters.very_very_very_long_parameter_name}}'''
-try: very_very_very_very_long_parameter_name = json.loads(r'''{{inputs.parameters.very_very_very_very_long_parameter_name}}''')
-except: very_very_very_very_long_parameter_name = r'''{{inputs.parameters.very_very_very_very_long_parameter_name}}'''
-try: very_very_very_very_very_long_parameter_name = json.loads(r'''{{inputs.parameters.very_very_very_very_very_long_parameter_name}}''')
-except: very_very_very_very_very_long_parameter_name = r'''{{inputs.parameters.very_very_very_very_very_long_parameter_name}}'''
+        expected_script = dedent(
+            """\
+            import os
+            import sys
+            sys.path.append(os.getcwd())
+            import json
+            try: very_long_parameter_name = json.loads(r'''{{inputs.parameters.very_long_parameter_name}}''')
+            except: very_long_parameter_name = r'''{{inputs.parameters.very_long_parameter_name}}'''
+            try: very_very_long_parameter_name = json.loads(r'''{{inputs.parameters.very_very_long_parameter_name}}''')
+            except: very_very_long_parameter_name = r'''{{inputs.parameters.very_very_long_parameter_name}}'''
+            try: very_very_very_long_parameter_name = json.loads(r'''{{inputs.parameters.very_very_very_long_parameter_name}}''')
+            except: very_very_very_long_parameter_name = r'''{{inputs.parameters.very_very_very_long_parameter_name}}'''
+            try: very_very_very_very_long_parameter_name = json.loads(r'''{{inputs.parameters.very_very_very_very_long_parameter_name}}''')
+            except: very_very_very_very_long_parameter_name = r'''{{inputs.parameters.very_very_very_very_long_parameter_name}}'''
+            try: very_very_very_very_very_long_parameter_name = json.loads(r'''{{inputs.parameters.very_very_very_very_very_long_parameter_name}}''')
+            except: very_very_very_very_very_long_parameter_name = r'''{{inputs.parameters.very_very_very_very_very_long_parameter_name}}'''
 
-print(42)
-"""
+            print(42)
+            """
+        )
         assert t._get_script() == expected_script
 
     def test_resources_returned_with_appropriate_limits(self, op):
@@ -277,13 +291,17 @@ print(42)
         assert isinstance(tt.daemon, bool)
         assert all([isinstance(x, _ArgoToleration) for x in tt.tolerations])
         assert tt.name == "t"
-        assert (
-            tt.script.source == "import os\nimport sys\nsys.path.append(os.getcwd())\n"
-            "import json\n"
-            "try: a = json.loads(r'''{{inputs.parameters.a}}''')\n"
-            "except: a = r'''{{inputs.parameters.a}}'''\n"
-            "\n"
-            "print(a)\n"
+        assert tt.script.source == dedent(
+            """\
+            import os
+            import sys
+            sys.path.append(os.getcwd())
+            import json
+            try: a = json.loads(r'''{{inputs.parameters.a}}''')
+            except: a = r'''{{inputs.parameters.a}}'''
+
+            print(a)
+            """
         )
         assert tt.inputs.parameters[0].name == "a"
         assert len(tt.tolerations) == 1

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -4,6 +4,7 @@ from unittest import mock
 from unittest.mock import Mock
 
 import pytest
+import yaml
 from argo_workflows.models import HostAlias as ArgoHostAlias
 from argo_workflows.models import (
     IoArgoprojWorkflowV1alpha1Workflow,
@@ -418,89 +419,22 @@ class TestWorkflow:
 
         hera.workflow._yaml = yaml
 
-    def test_to_yaml(self):
+    @pytest.mark.parametrize(
+        ["roundtripper"],
+        (
+            pytest.param(lambda w: w.to_dict(), id="dict"),
+            pytest.param(lambda w: json.loads(w.to_json()), id="json"),
+            pytest.param(lambda w: yaml.safe_load(w.to_yaml()), id="yaml"),
+        ),
+    )
+    def test_serialization(self, roundtripper):
         def hello():
             print("Hello, Hera!")
 
         with Workflow("hello-hera", node_selectors={'a_b_c': 'a_b_c'}, labels={'a_b_c': 'a_b_c'}) as w:
             Task("t", hello)
 
-        expected_yaml = """apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  labels:
-    a_b_c: a_b_c
-  name: hello-hera
-spec:
-  entrypoint: hello-hera
-  nodeSelector:
-    a_b_c: a_b_c
-  templates:
-  - name: t
-    script:
-      command:
-      - python
-      image: python:3.7
-      source: 'import os
-
-        import sys
-
-        sys.path.append(os.getcwd())
-
-        print("Hello, Hera!")
-
-        '
-  - dag:
-      tasks:
-      - name: t
-        template: t
-    name: hello-hera
-"""
-        assert w.to_yaml() == expected_yaml
-
-    def test_to_dict(self):
-        def hello():
-            print("Hello, Hera!")
-
-        with Workflow("hello-hera", node_selectors={'a_b_c': 'a_b_c'}, labels={'a_b_c': 'a_b_c'}) as w:
-            Task("t", hello)
-        expected_dict = {
-            'metadata': {'name': 'hello-hera', 'labels': {'a_b_c': 'a_b_c'}},
-            'spec': {
-                'entrypoint': 'hello-hera',
-                'templates': [
-                    {
-                        'name': 't',
-                        'script': {
-                            'image': 'python:3.7',
-                            'source': dedent(
-                                """\
-                                import os
-                                import sys
-                                sys.path.append(os.getcwd())
-                                print("Hello, Hera!")
-                                """
-                            ),
-                            'command': ['python'],
-                        },
-                    },
-                    {'name': 'hello-hera', 'dag': {'tasks': [{'name': 't', 'template': 't'}]}},
-                ],
-                'nodeSelector': {'a_b_c': 'a_b_c'},
-            },
-            'apiVersion': 'argoproj.io/v1alpha1',
-            'kind': 'Workflow',
-        }
-        assert expected_dict == w.to_dict()
-
-    def test_to_json(self):
-        def hello():
-            print("Hello, Hera!")
-
-        with Workflow("hello-hera", node_selectors={'a_b_c': 'a_b_c'}, labels={'a_b_c': 'a_b_c'}) as w:
-            Task("t", hello)
-
-        expected_json = {
+        expected = {
             "metadata": {"name": "hello-hera", "labels": {"a_b_c": "a_b_c"}},
             "spec": {
                 "entrypoint": "hello-hera",
@@ -527,7 +461,7 @@ spec:
             "apiVersion": "argoproj.io/v1alpha1",
             "kind": "Workflow",
         }
-        assert expected_json == json.loads(w.to_json())
+        assert expected == roundtripper(w)
 
     def test_workflow_applies_hooks(self, global_config):
         def hook1(w: Workflow) -> None:

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,3 +1,5 @@
+import json
+from textwrap import dedent
 from unittest import mock
 from unittest.mock import Mock
 
@@ -471,7 +473,14 @@ spec:
                         'name': 't',
                         'script': {
                             'image': 'python:3.7',
-                            'source': 'import os\nimport sys\nsys.path.append(os.getcwd())\nprint("Hello, Hera!")\n',
+                            'source': dedent(
+                                """\
+                                import os
+                                import sys
+                                sys.path.append(os.getcwd())
+                                print("Hello, Hera!")
+                                """
+                            ),
                             'command': ['python'],
                         },
                     },
@@ -491,16 +500,34 @@ spec:
         with Workflow("hello-hera", node_selectors={'a_b_c': 'a_b_c'}, labels={'a_b_c': 'a_b_c'}) as w:
             Task("t", hello)
 
-        expected_json = (
-            '{"metadata": {"name": "hello-hera", "labels": {"a_b_c": "a_b_c"}}, "spec": '
-            '{"entrypoint": "hello-hera", "templates": [{"name": "t", "script": {"image": '
-            '"python:3.7", "source": "import os\\nimport '
-            'sys\\nsys.path.append(os.getcwd())\\nprint(\\"Hello, Hera!\\")\\n", '
-            '"command": ["python"]}}, {"name": "hello-hera", "dag": {"tasks": [{"name": '
-            '"t", "template": "t"}]}}], "nodeSelector": {"a_b_c": "a_b_c"}}, '
-            '"apiVersion": "argoproj.io/v1alpha1", "kind": "Workflow"}'
-        )
-        assert expected_json == w.to_json()
+        expected_json = {
+            "metadata": {"name": "hello-hera", "labels": {"a_b_c": "a_b_c"}},
+            "spec": {
+                "entrypoint": "hello-hera",
+                "templates": [
+                    {
+                        "name": "t",
+                        "script": {
+                            "image": "python:3.7",
+                            "source": dedent(
+                                """\
+                                import os
+                                import sys
+                                sys.path.append(os.getcwd())
+                                print("Hello, Hera!")
+                                """
+                            ),
+                            "command": ["python"],
+                        },
+                    },
+                    {"name": "hello-hera", "dag": {"tasks": [{"name": "t", "template": "t"}]}},
+                ],
+                "nodeSelector": {"a_b_c": "a_b_c"},
+            },
+            "apiVersion": "argoproj.io/v1alpha1",
+            "kind": "Workflow",
+        }
+        assert expected_json == json.loads(w.to_json())
 
     def test_workflow_applies_hooks(self, global_config):
         def hook1(w: Workflow) -> None:


### PR DESCRIPTION
The tests comparing to static generated script output are a bit tricky to read and update due to the string continuations and special characters. Before making other changes to the generated scripts, I wanted to tidy this up to keep the PR tidy.

This changes the script comparisons to use multiline strings with `textwrap.dedent`.
