### PR TITLE
Support multiprocessing scripts

### DIFF
--- a/src/hera/task.py
+++ b/src/hera/task.py
@@ -877,7 +877,13 @@ class Task(IO):
 
                 s = "".join(content[token_index:])
                 script += textwrap.dedent(s)
-                return textwrap.dedent(script)
+                script = textwrap.dedent(script)
+                # Guard everything under a main check to avoid recursive issues with
+                # tasks that import the defining module (eg: multiprocessing).
+                res = "if __name__ == '__main__':"
+                for line in script.split("\n"):
+                    res += f"\n    {line}" if line else "\n"
+                return res
         else:
             assert isinstance(self.source, str)
             return self.source

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1,4 +1,5 @@
 import json
+from textwrap import dedent
 from unittest import mock
 
 import pytest
@@ -99,34 +100,44 @@ class TestTask:
     def test_param_script_portion_adds_formatted_json_calls(self, op):
         t = Task("t", op, [{"a": 1}])
         script = t._get_param_script_portion()
-        assert (
-            script == "import json\n"
-            "try: a = json.loads(r'''{{inputs.parameters.a}}''')\n"
-            "except: a = r'''{{inputs.parameters.a}}'''\n"
+        assert script == dedent(
+            """\
+            import json
+            try: a = json.loads(r'''{{inputs.parameters.a}}''')
+            except: a = r'''{{inputs.parameters.a}}'''
+            """
         )
 
     def test_script_getter_returns_expected_string(self, op, typed_op):
         t = Task("t", op, [{"a": 1}])
         script = t._get_script()
-        assert (
-            script == "import os\nimport sys\nsys.path.append(os.getcwd())\n"
-            "import json\n"
-            "try: a = json.loads(r'''{{inputs.parameters.a}}''')\n"
-            "except: a = r'''{{inputs.parameters.a}}'''\n"
-            "\n"
-            "print(a)\n"
+        assert script == dedent(
+            """\
+            import os
+            import sys
+            sys.path.append(os.getcwd())
+            import json
+            try: a = json.loads(r'''{{inputs.parameters.a}}''')
+            except: a = r'''{{inputs.parameters.a}}'''
+
+            print(a)
+            """
         )
 
         t = Task("t", typed_op, [{"a": 1}])
         script = t._get_script()
-        assert (
-            script == "import os\nimport sys\nsys.path.append(os.getcwd())\n"
-            "import json\n"
-            "try: a = json.loads(r'''{{inputs.parameters.a}}''')\n"
-            "except: a = r'''{{inputs.parameters.a}}'''\n"
-            "\n"
-            "print(a)\n"
-            'return [{"a": (a, a)}]\n'
+        assert script == dedent(
+            """\
+            import os
+            import sys
+            sys.path.append(os.getcwd())
+            import json
+            try: a = json.loads(r'''{{inputs.parameters.a}}''')
+            except: a = r'''{{inputs.parameters.a}}'''
+
+            print(a)
+            return [{"a": (a, a)}]
+            """
         )
 
     def test_script_getter_parses_multi_line_function(self, long_op):
@@ -144,23 +155,26 @@ class TestTask:
             ],
         )
 
-        expected_script = """import os
-import sys
-sys.path.append(os.getcwd())
-import json
-try: very_long_parameter_name = json.loads(r'''{{inputs.parameters.very_long_parameter_name}}''')
-except: very_long_parameter_name = r'''{{inputs.parameters.very_long_parameter_name}}'''
-try: very_very_long_parameter_name = json.loads(r'''{{inputs.parameters.very_very_long_parameter_name}}''')
-except: very_very_long_parameter_name = r'''{{inputs.parameters.very_very_long_parameter_name}}'''
-try: very_very_very_long_parameter_name = json.loads(r'''{{inputs.parameters.very_very_very_long_parameter_name}}''')
-except: very_very_very_long_parameter_name = r'''{{inputs.parameters.very_very_very_long_parameter_name}}'''
-try: very_very_very_very_long_parameter_name = json.loads(r'''{{inputs.parameters.very_very_very_very_long_parameter_name}}''')
-except: very_very_very_very_long_parameter_name = r'''{{inputs.parameters.very_very_very_very_long_parameter_name}}'''
-try: very_very_very_very_very_long_parameter_name = json.loads(r'''{{inputs.parameters.very_very_very_very_very_long_parameter_name}}''')
-except: very_very_very_very_very_long_parameter_name = r'''{{inputs.parameters.very_very_very_very_very_long_parameter_name}}'''
+        expected_script = dedent(
+            """\
+            import os
+            import sys
+            sys.path.append(os.getcwd())
+            import json
+            try: very_long_parameter_name = json.loads(r'''{{inputs.parameters.very_long_parameter_name}}''')
+            except: very_long_parameter_name = r'''{{inputs.parameters.very_long_parameter_name}}'''
+            try: very_very_long_parameter_name = json.loads(r'''{{inputs.parameters.very_very_long_parameter_name}}''')
+            except: very_very_long_parameter_name = r'''{{inputs.parameters.very_very_long_parameter_name}}'''
+            try: very_very_very_long_parameter_name = json.loads(r'''{{inputs.parameters.very_very_very_long_parameter_name}}''')
+            except: very_very_very_long_parameter_name = r'''{{inputs.parameters.very_very_very_long_parameter_name}}'''
+            try: very_very_very_very_long_parameter_name = json.loads(r'''{{inputs.parameters.very_very_very_very_long_parameter_name}}''')
+            except: very_very_very_very_long_parameter_name = r'''{{inputs.parameters.very_very_very_very_long_parameter_name}}'''
+            try: very_very_very_very_very_long_parameter_name = json.loads(r'''{{inputs.parameters.very_very_very_very_very_long_parameter_name}}''')
+            except: very_very_very_very_very_long_parameter_name = r'''{{inputs.parameters.very_very_very_very_very_long_parameter_name}}'''
 
-print(42)
-"""
+            print(42)
+            """
+        )
         assert t._get_script() == expected_script
 
     def test_resources_returned_with_appropriate_limits(self, op):
@@ -277,13 +291,17 @@ print(42)
         assert isinstance(tt.daemon, bool)
         assert all([isinstance(x, _ArgoToleration) for x in tt.tolerations])
         assert tt.name == "t"
-        assert (
-            tt.script.source == "import os\nimport sys\nsys.path.append(os.getcwd())\n"
-            "import json\n"
-            "try: a = json.loads(r'''{{inputs.parameters.a}}''')\n"
-            "except: a = r'''{{inputs.parameters.a}}'''\n"
-            "\n"
-            "print(a)\n"
+        assert tt.script.source == dedent(
+            """\
+            import os
+            import sys
+            sys.path.append(os.getcwd())
+            import json
+            try: a = json.loads(r'''{{inputs.parameters.a}}''')
+            except: a = r'''{{inputs.parameters.a}}'''
+
+            print(a)
+            """
         )
         assert tt.inputs.parameters[0].name == "a"
         assert len(tt.tolerations) == 1

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -113,14 +113,15 @@ class TestTask:
         script = t._get_script()
         assert script == dedent(
             """\
-            import os
-            import sys
-            sys.path.append(os.getcwd())
-            import json
-            try: a = json.loads(r'''{{inputs.parameters.a}}''')
-            except: a = r'''{{inputs.parameters.a}}'''
+            if __name__ == '__main__':
+                import os
+                import sys
+                sys.path.append(os.getcwd())
+                import json
+                try: a = json.loads(r'''{{inputs.parameters.a}}''')
+                except: a = r'''{{inputs.parameters.a}}'''
 
-            print(a)
+                print(a)
             """
         )
 
@@ -128,15 +129,16 @@ class TestTask:
         script = t._get_script()
         assert script == dedent(
             """\
-            import os
-            import sys
-            sys.path.append(os.getcwd())
-            import json
-            try: a = json.loads(r'''{{inputs.parameters.a}}''')
-            except: a = r'''{{inputs.parameters.a}}'''
+            if __name__ == '__main__':
+                import os
+                import sys
+                sys.path.append(os.getcwd())
+                import json
+                try: a = json.loads(r'''{{inputs.parameters.a}}''')
+                except: a = r'''{{inputs.parameters.a}}'''
 
-            print(a)
-            return [{"a": (a, a)}]
+                print(a)
+                return [{"a": (a, a)}]
             """
         )
 
@@ -157,22 +159,23 @@ class TestTask:
 
         expected_script = dedent(
             """\
-            import os
-            import sys
-            sys.path.append(os.getcwd())
-            import json
-            try: very_long_parameter_name = json.loads(r'''{{inputs.parameters.very_long_parameter_name}}''')
-            except: very_long_parameter_name = r'''{{inputs.parameters.very_long_parameter_name}}'''
-            try: very_very_long_parameter_name = json.loads(r'''{{inputs.parameters.very_very_long_parameter_name}}''')
-            except: very_very_long_parameter_name = r'''{{inputs.parameters.very_very_long_parameter_name}}'''
-            try: very_very_very_long_parameter_name = json.loads(r'''{{inputs.parameters.very_very_very_long_parameter_name}}''')
-            except: very_very_very_long_parameter_name = r'''{{inputs.parameters.very_very_very_long_parameter_name}}'''
-            try: very_very_very_very_long_parameter_name = json.loads(r'''{{inputs.parameters.very_very_very_very_long_parameter_name}}''')
-            except: very_very_very_very_long_parameter_name = r'''{{inputs.parameters.very_very_very_very_long_parameter_name}}'''
-            try: very_very_very_very_very_long_parameter_name = json.loads(r'''{{inputs.parameters.very_very_very_very_very_long_parameter_name}}''')
-            except: very_very_very_very_very_long_parameter_name = r'''{{inputs.parameters.very_very_very_very_very_long_parameter_name}}'''
+            if __name__ == '__main__':
+                import os
+                import sys
+                sys.path.append(os.getcwd())
+                import json
+                try: very_long_parameter_name = json.loads(r'''{{inputs.parameters.very_long_parameter_name}}''')
+                except: very_long_parameter_name = r'''{{inputs.parameters.very_long_parameter_name}}'''
+                try: very_very_long_parameter_name = json.loads(r'''{{inputs.parameters.very_very_long_parameter_name}}''')
+                except: very_very_long_parameter_name = r'''{{inputs.parameters.very_very_long_parameter_name}}'''
+                try: very_very_very_long_parameter_name = json.loads(r'''{{inputs.parameters.very_very_very_long_parameter_name}}''')
+                except: very_very_very_long_parameter_name = r'''{{inputs.parameters.very_very_very_long_parameter_name}}'''
+                try: very_very_very_very_long_parameter_name = json.loads(r'''{{inputs.parameters.very_very_very_very_long_parameter_name}}''')
+                except: very_very_very_very_long_parameter_name = r'''{{inputs.parameters.very_very_very_very_long_parameter_name}}'''
+                try: very_very_very_very_very_long_parameter_name = json.loads(r'''{{inputs.parameters.very_very_very_very_very_long_parameter_name}}''')
+                except: very_very_very_very_very_long_parameter_name = r'''{{inputs.parameters.very_very_very_very_very_long_parameter_name}}'''
 
-            print(42)
+                print(42)
             """
         )
         assert t._get_script() == expected_script
@@ -293,14 +296,15 @@ class TestTask:
         assert tt.name == "t"
         assert tt.script.source == dedent(
             """\
-            import os
-            import sys
-            sys.path.append(os.getcwd())
-            import json
-            try: a = json.loads(r'''{{inputs.parameters.a}}''')
-            except: a = r'''{{inputs.parameters.a}}'''
+            if __name__ == '__main__':
+                import os
+                import sys
+                sys.path.append(os.getcwd())
+                import json
+                try: a = json.loads(r'''{{inputs.parameters.a}}''')
+                except: a = r'''{{inputs.parameters.a}}'''
 
-            print(a)
+                print(a)
             """
         )
         assert tt.inputs.parameters[0].name == "a"

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -4,6 +4,7 @@ from unittest import mock
 from unittest.mock import Mock
 
 import pytest
+import yaml
 from argo_workflows.models import HostAlias as ArgoHostAlias
 from argo_workflows.models import (
     IoArgoprojWorkflowV1alpha1Workflow,
@@ -418,89 +419,22 @@ class TestWorkflow:
 
         hera.workflow._yaml = yaml
 
-    def test_to_yaml(self):
+    @pytest.mark.parametrize(
+        ["roundtripper"],
+        (
+            pytest.param(lambda w: w.to_dict(), id="dict"),
+            pytest.param(lambda w: json.loads(w.to_json()), id="json"),
+            pytest.param(lambda w: yaml.safe_load(w.to_yaml()), id="yaml"),
+        ),
+    )
+    def test_serialization(self, roundtripper):
         def hello():
             print("Hello, Hera!")
 
         with Workflow("hello-hera", node_selectors={'a_b_c': 'a_b_c'}, labels={'a_b_c': 'a_b_c'}) as w:
             Task("t", hello)
 
-        expected_yaml = """apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  labels:
-    a_b_c: a_b_c
-  name: hello-hera
-spec:
-  entrypoint: hello-hera
-  nodeSelector:
-    a_b_c: a_b_c
-  templates:
-  - name: t
-    script:
-      command:
-      - python
-      image: python:3.7
-      source: 'import os
-
-        import sys
-
-        sys.path.append(os.getcwd())
-
-        print("Hello, Hera!")
-
-        '
-  - dag:
-      tasks:
-      - name: t
-        template: t
-    name: hello-hera
-"""
-        assert w.to_yaml() == expected_yaml
-
-    def test_to_dict(self):
-        def hello():
-            print("Hello, Hera!")
-
-        with Workflow("hello-hera", node_selectors={'a_b_c': 'a_b_c'}, labels={'a_b_c': 'a_b_c'}) as w:
-            Task("t", hello)
-        expected_dict = {
-            'metadata': {'name': 'hello-hera', 'labels': {'a_b_c': 'a_b_c'}},
-            'spec': {
-                'entrypoint': 'hello-hera',
-                'templates': [
-                    {
-                        'name': 't',
-                        'script': {
-                            'image': 'python:3.7',
-                            'source': dedent(
-                                """\
-                                import os
-                                import sys
-                                sys.path.append(os.getcwd())
-                                print("Hello, Hera!")
-                                """
-                            ),
-                            'command': ['python'],
-                        },
-                    },
-                    {'name': 'hello-hera', 'dag': {'tasks': [{'name': 't', 'template': 't'}]}},
-                ],
-                'nodeSelector': {'a_b_c': 'a_b_c'},
-            },
-            'apiVersion': 'argoproj.io/v1alpha1',
-            'kind': 'Workflow',
-        }
-        assert expected_dict == w.to_dict()
-
-    def test_to_json(self):
-        def hello():
-            print("Hello, Hera!")
-
-        with Workflow("hello-hera", node_selectors={'a_b_c': 'a_b_c'}, labels={'a_b_c': 'a_b_c'}) as w:
-            Task("t", hello)
-
-        expected_json = {
+        expected = {
             "metadata": {"name": "hello-hera", "labels": {"a_b_c": "a_b_c"}},
             "spec": {
                 "entrypoint": "hello-hera",
@@ -527,7 +461,7 @@ spec:
             "apiVersion": "argoproj.io/v1alpha1",
             "kind": "Workflow",
         }
-        assert expected_json == json.loads(w.to_json())
+        assert expected == roundtripper(w)
 
     def test_workflow_applies_hooks(self, global_config):
         def hook1(w: Workflow) -> None:

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,3 +1,5 @@
+import json
+from textwrap import dedent
 from unittest import mock
 from unittest.mock import Mock
 
@@ -471,7 +473,14 @@ spec:
                         'name': 't',
                         'script': {
                             'image': 'python:3.7',
-                            'source': 'import os\nimport sys\nsys.path.append(os.getcwd())\nprint("Hello, Hera!")\n',
+                            'source': dedent(
+                                """\
+                                import os
+                                import sys
+                                sys.path.append(os.getcwd())
+                                print("Hello, Hera!")
+                                """
+                            ),
                             'command': ['python'],
                         },
                     },
@@ -491,16 +500,34 @@ spec:
         with Workflow("hello-hera", node_selectors={'a_b_c': 'a_b_c'}, labels={'a_b_c': 'a_b_c'}) as w:
             Task("t", hello)
 
-        expected_json = (
-            '{"metadata": {"name": "hello-hera", "labels": {"a_b_c": "a_b_c"}}, "spec": '
-            '{"entrypoint": "hello-hera", "templates": [{"name": "t", "script": {"image": '
-            '"python:3.7", "source": "import os\\nimport '
-            'sys\\nsys.path.append(os.getcwd())\\nprint(\\"Hello, Hera!\\")\\n", '
-            '"command": ["python"]}}, {"name": "hello-hera", "dag": {"tasks": [{"name": '
-            '"t", "template": "t"}]}}], "nodeSelector": {"a_b_c": "a_b_c"}}, '
-            '"apiVersion": "argoproj.io/v1alpha1", "kind": "Workflow"}'
-        )
-        assert expected_json == w.to_json()
+        expected_json = {
+            "metadata": {"name": "hello-hera", "labels": {"a_b_c": "a_b_c"}},
+            "spec": {
+                "entrypoint": "hello-hera",
+                "templates": [
+                    {
+                        "name": "t",
+                        "script": {
+                            "image": "python:3.7",
+                            "source": dedent(
+                                """\
+                                import os
+                                import sys
+                                sys.path.append(os.getcwd())
+                                print("Hello, Hera!")
+                                """
+                            ),
+                            "command": ["python"],
+                        },
+                    },
+                    {"name": "hello-hera", "dag": {"tasks": [{"name": "t", "template": "t"}]}},
+                ],
+                "nodeSelector": {"a_b_c": "a_b_c"},
+            },
+            "apiVersion": "argoproj.io/v1alpha1",
+            "kind": "Workflow",
+        }
+        assert expected_json == json.loads(w.to_json())
 
     def test_workflow_applies_hooks(self, global_config):
         def hook1(w: Workflow) -> None:

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -445,10 +445,11 @@ class TestWorkflow:
                             "image": "python:3.7",
                             "source": dedent(
                                 """\
-                                import os
-                                import sys
-                                sys.path.append(os.getcwd())
-                                print("Hello, Hera!")
+                                if __name__ == '__main__':
+                                    import os
+                                    import sys
+                                    sys.path.append(os.getcwd())
+                                    print("Hello, Hera!")
                                 """
                             ),
                             "command": ["python"],


### PR DESCRIPTION
NOTE: This PR is based off of https://github.com/argoproj-labs/hera-workflows/pull/413 to keep the diff cleaner (... I guess PRs from forks can't use base branches also from the fork, so just look at the last commit I guess haha and I can try to rebase once/if that is merged).

When using `multiprocessing` directly or indirectly (eg: with `dask.distributed.Client()`) in a task, forked subprocesses attempt to import the script again, causing recursive errors. A user can manually add an `if __name__ == "__main__":` check to their code, however this is hard to intuit ahead of time (the issue only arises *once run in Argo*, since when called normally as a function, imports won't cause issues) and can make tasks harder to test programmatically (again, calling the task func in a test won't pass the `__main__` comparison).

The fact that Hera embeds the function's *source code* directly as a module is an implementation detail, so it seems right to have Hera automatically add the `__main__` checks.

---

For example, when run directly as a script, this code:

```
from multiprocessing import Pool

chars = [72, 101, 114, 97]
with Pool(5) as p:
    print("".join(p.map(chr, chars)))
```

will repeatedly (infinitely?) error with:

```
RuntimeError:
        An attempt has been made to start a new process before the
        current process has finished its bootstrapping phase.

        This probably means that you are not using fork to start your
        child processes and you have forgotten to use the proper idiom
        in the main module:

            if __name__ == '__main__':
                freeze_support()
                ...

        The "freeze_support()" line can be omitted if the program
        is not going to be frozen to produce an executable.
```
