### PR TITLE
Remove subset type within Union

### DIFF
--- a/src/hera/io.py
+++ b/src/hera/io.py
@@ -17,7 +17,6 @@ class IO:
     Parameters
     ----------
     inputs: Union[
-        List[Union[Parameter, Artifact]],
         List[Union[Parameter, Artifact, Dict[str, Any]]],
         Dict[str, Any],
     ] = None,
@@ -29,7 +28,6 @@ class IO:
     """
 
     inputs: Union[
-        List[Union[Parameter, Artifact]],
         List[Union[Parameter, Artifact, Dict[str, Any]]],
         Dict[str, Any],
     ] = field(  # type: ignore

--- a/src/hera/io.py
+++ b/src/hera/io.py
@@ -17,6 +17,7 @@ class IO:
     Parameters
     ----------
     inputs: Union[
+        List[Union[Parameter, Artifact]],
         List[Union[Parameter, Artifact, Dict[str, Any]]],
         Dict[str, Any],
     ] = None,
@@ -28,6 +29,7 @@ class IO:
     """
 
     inputs: Union[
+        List[Union[Parameter, Artifact]],
         List[Union[Parameter, Artifact, Dict[str, Any]]],
         Dict[str, Any],
     ] = field(  # type: ignore
@@ -41,7 +43,9 @@ class IO:
     def _parse_inputs(
         self,
         inputs: Union[
-            List[Union[Parameter, Artifact]], List[Union[Parameter, Artifact, Dict[str, Any]]], Dict[str, Any]
+            List[Union[Parameter, Artifact]],
+            List[Union[Parameter, Artifact, Dict[str, Any]]],
+            Dict[str, Any],
         ],
     ) -> List[Union[Parameter, Artifact]]:
         """Parses the dictionary aspect of the specified inputs and returns a list of parameters and artifacts.
@@ -56,7 +60,7 @@ class IO:
         Returns
         -------
         List[Union[Parameter, Artifact]]
-            A list of parameters and artifacts. The parameters contain the specified dictionary mapping as well, as
+            A list of parameters and artifacts. The parameters contain the specified dictionary mapping as well as
             independent parameters.
         """
         result: List[Union[Parameter, Artifact]] = []

--- a/src/hera/task.py
+++ b/src/hera/task.py
@@ -93,7 +93,6 @@ class Task(IO):
         https://argoproj.github.io/argo-workflows/fields/#sequence.
     inputs: Optional[
             Union[
-                List[Union[Parameter, Artifact]],
                 List[Union[Parameter, Artifact, Dict[str, Any]]],
                 Dict[str, Any],
             ]
@@ -186,7 +185,7 @@ class Task(IO):
         with_param: Optional[Any] = None,
         with_sequence: Optional[Sequence] = None,
         inputs: Optional[
-            Union[List[Union[Parameter, Artifact]], List[Union[Parameter, Artifact, Dict[str, Any]]], Dict[str, Any]]
+            Union[List[Union[Parameter, Artifact, Dict[str, Any]]], Dict[str, Any]]
         ] = None,
         outputs: Optional[List[Union[Parameter, Artifact]]] = None,
         dag: Optional[DAG] = None,

--- a/src/hera/task.py
+++ b/src/hera/task.py
@@ -274,9 +274,6 @@ class Task(IO):
 
         self.validate()
 
-        # here we cast for otherwise `mypy` complains that Hera adds an incompatible type with a dictionary, which is
-        # an acceptable type for the `inputs` field upon `init`
-        self.inputs = cast(List[Union[Parameter, Artifact]], self.inputs)
         self.inputs += self._deduce_input_params()
 
         if hera.dag_context.is_set():

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -14,4 +14,4 @@ def test_version():
     except Exception:
         raise
     if len(version_info) == 4:
-        assert ("dev" in version_info[3] or "rc" in version_info[3])
+        assert "dev" in version_info[3] or "rc" in version_info[3]


### PR DESCRIPTION
* `Union[A, B]` is a subset of `Union[A, B, C]`, which is the case for the Parameter/Artifact/Dict types used for the inputs type, which was causing mypy complaints - we don't need to use Sequence if we remove the unnecessary component of the Union:

```
$ mypy examples/input_output.py
examples/input_output.py:16: error: Argument "inputs" to "Task" has incompatible type "List[Parameter]"; expected "Union[List[Union[Parameter, Artifact]], List[Union[Parameter, Artifact, Dict[str, Any]]], Dict[str, Any], None]"  [arg-type]
examples/input_output.py:16: note: "List" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
examples/input_output.py:16: note: Consider using "Sequence" instead, which is covariant
```

This PR changes the parameters `inputs` type passed in to a `Task`, but not the underlying IO class's `inputs` type, meaning we can streamline some of the types in the `Task` class only.

Signed-off-by: Elliot Gunton <egunton@bloomberg.net>