### PR TITLE
Remove restrictions from enums/defaults

### DIFF
--- a/src/hera/parameter.py
+++ b/src/hera/parameter.py
@@ -59,10 +59,6 @@ class Parameter:
     ) -> None:
         if value is not MISSING and value_from is not None:
             raise ValueError("Cannot specify both `value` and `value_from` when instantiating `Parameter`")
-        if enum and value is not MISSING and value not in enum:
-            raise ValueError("`value` must be in `enum`")
-        if enum and default is not MISSING and default not in enum:
-            raise ValueError("`default` must be in `enum`")
         self.name = name
         self.value = _serialize(value)
         self.default = _serialize(default)

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -14,16 +14,6 @@ class TestParameter:
             Parameter("a", value_from=ValueFrom(default="42"), value="42")
         assert str(e.value) == "Cannot specify both `value` and `value_from` when instantiating `Parameter`"
 
-    def test_init_raises_value_error_using_invalid_value_with_enum(self):
-        with pytest.raises(ValueError) as e:
-            Parameter("a", value="42", enum=["41"])
-        assert str(e.value) == "`value` must be in `enum`"
-
-    def test_init_raises_value_error_using_invalid_default_with_enum(self):
-        with pytest.raises(ValueError) as e:
-            Parameter("a", default="42", enum=["41"])
-        assert str(e.value) == "`default` must be in `enum`"
-
     def test_as_name_returns_expected_parameter(self):
         p = Parameter("a", value="42").as_name("b")
         assert isinstance(p, Parameter)


### PR DESCRIPTION
enums/default values may be sourced from an expression/variable. In that case, the strict validation that hera performs currently to check if they are present in the enum may be invalid.

Remove this validation.
