### PR TITLE
Add PVC inference 

### DIFF
--- a/docs/examples/workflows/upstream/volumes_pvc.md
+++ b/docs/examples/workflows/upstream/volumes_pvc.md
@@ -46,43 +46,49 @@ spec:
 ## Hera
 
 ```python
-from hera.workflows import Workflow, Volume, Container, Steps, models as m
+from hera.workflows import (
+    Container,
+    Steps,
+    Volume,
+    Workflow,
+    models as m,
+)
 
 with Workflow(
     generate_name="volumes-pvc-",
     entrypoint="volumes-pvc-example",
-    volume_claim_templates=[m.PersistentVolumeClaim(
-        metadata=m.ObjectMeta(name="workdir"),
-        spec=m.PersistentVolumeClaimSpec(
-            access_modes=["ReadWriteOnce"],
-            resources=m.ResourceRequirements(
-                requests={"storage": m.Quantity(__root__="1Gi")},
-            )
-        ),
-    )]
+    volume_claim_templates=[
+        m.PersistentVolumeClaim(
+            metadata=m.ObjectMeta(name="workdir"),
+            spec=m.PersistentVolumeClaimSpec(
+                access_modes=["ReadWriteOnce"],
+                resources=m.ResourceRequirements(
+                    requests={"storage": m.Quantity(__root__="1Gi")},
+                ),
+            ),
+        )
+    ],
 ) as w:
     v = Volume(
-            name="workdir",
-            size="1Gi",
-            mount_path="/mnt/vol",
-            access_modes=["ReadWriteOnce"],
-        )
+        name="workdir",
+        size="1Gi",
+        mount_path="/mnt/vol",
+        access_modes=["ReadWriteOnce"],
+    )
     whalesay = Container(
         name="whalesay",
         image="docker/whalesay:latest",
         command=["sh", "-c"],
-        args=[
-            "echo generating message in volume; cowsay hello world | tee /mnt/vol/hello_world.txt"
-        ],
-        volume_mounts=[m.VolumeMount(name="workdir", mount_path="/mnt/vol")])
+        args=["echo generating message in volume; cowsay hello world | tee /mnt/vol/hello_world.txt"],
+        volume_mounts=[m.VolumeMount(name="workdir", mount_path="/mnt/vol")],
+    )
     print_message = Container(
         name="print-message",
         image="alpine:latest",
         command=["sh", "-c"],
-        args=[
-            "echo getting message from volume; find /mnt/vol; cat /mnt/vol/hello_world.txt"
-        ],
-        volume_mounts=[m.VolumeMount(name="workdir", mount_path="/mnt/vol")])
+        args=["echo getting message from volume; find /mnt/vol; cat /mnt/vol/hello_world.txt"],
+        volume_mounts=[m.VolumeMount(name="workdir", mount_path="/mnt/vol")],
+    )
     with Steps(name="volumes-pvc-example") as s:
         whalesay(name="generate")
         print_message(name="print")

--- a/docs/examples/workflows/upstream/volumes_pvc.md
+++ b/docs/examples/workflows/upstream/volumes_pvc.md
@@ -1,0 +1,138 @@
+# Volumes Pvc
+
+> Note: This example is a replication of an Argo Workflow example in Hera. The upstream example can be [found here](https://github.com/argoproj/argo-workflows/blob/master/examples/volumes-pvc.yaml).
+
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: volumes-pvc-
+spec:
+  entrypoint: volumes-pvc-example
+  volumeClaimTemplates:
+  - metadata:
+      name: workdir
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 1Gi
+
+  templates:
+  - name: volumes-pvc-example
+    steps:
+    - - name: generate
+        template: whalesay
+    - - name: print
+        template: print-message
+
+  - name: whalesay
+    container:
+      image: docker/whalesay:latest
+      command: [sh, -c]
+      args: ["echo generating message in volume; cowsay hello world | tee /mnt/vol/hello_world.txt"]
+      volumeMounts:
+      - name: workdir
+        mountPath: /mnt/vol
+
+  - name: print-message
+    container:
+      image: alpine:latest
+      command: [sh, -c]
+      args: ["echo getting message from volume; find /mnt/vol; cat /mnt/vol/hello_world.txt"]
+      volumeMounts:
+      - name: workdir
+        mountPath: /mnt/vol
+
+## Hera
+
+```python
+from hera.workflows import Workflow, Volume, Container, Steps, models as m
+
+with Workflow(
+    generate_name="volumes-pvc-",
+    entrypoint="volumes-pvc-example",
+    volume_claim_templates=[m.PersistentVolumeClaim(
+        metadata=m.ObjectMeta(name="workdir"),
+        spec=m.PersistentVolumeClaimSpec(
+            access_modes=["ReadWriteOnce"],
+            resources=m.ResourceRequirements(
+                requests={"storage": m.Quantity(__root__="1Gi")},
+            )
+        ),
+    )]
+) as w:
+    v = Volume(
+            name="workdir",
+            size="1Gi",
+            mount_path="/mnt/vol",
+            access_modes=["ReadWriteOnce"],
+        )
+    whalesay = Container(
+        name="whalesay",
+        image="docker/whalesay:latest",
+        command=["sh", "-c"],
+        args=[
+            "echo generating message in volume; cowsay hello world | tee /mnt/vol/hello_world.txt"
+        ],
+        volume_mounts=[m.VolumeMount(name="workdir", mount_path="/mnt/vol")])
+    print_message = Container(
+        name="print-message",
+        image="alpine:latest",
+        command=["sh", "-c"],
+        args=[
+            "echo getting message from volume; find /mnt/vol; cat /mnt/vol/hello_world.txt"
+        ],
+        volume_mounts=[m.VolumeMount(name="workdir", mount_path="/mnt/vol")])
+    with Steps(name="volumes-pvc-example") as s:
+        whalesay(name="generate")
+        print_message(name="print")
+```
+
+## YAML
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: volumes-pvc-
+spec:
+  entrypoint: volumes-pvc-example
+  templates:
+  - container:
+      args:
+      - echo generating message in volume; cowsay hello world | tee /mnt/vol/hello_world.txt
+      command:
+      - sh
+      - -c
+      image: docker/whalesay:latest
+      volumeMounts:
+      - mountPath: /mnt/vol
+        name: workdir
+    name: whalesay
+  - container:
+      args:
+      - echo getting message from volume; find /mnt/vol; cat /mnt/vol/hello_world.txt
+      command:
+      - sh
+      - -c
+      image: alpine:latest
+      volumeMounts:
+      - mountPath: /mnt/vol
+        name: workdir
+    name: print-message
+  - name: volumes-pvc-example
+    steps:
+    - - name: generate
+        template: whalesay
+    - - name: print
+        template: print-message
+  volumeClaimTemplates:
+  - metadata:
+      name: workdir
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 1Gi
+```

--- a/examples/workflows/upstream/conditional-artifacts.upstream.yaml
+++ b/examples/workflows/upstream/conditional-artifacts.upstream.yaml
@@ -6,7 +6,7 @@ metadata:
     workflows.argoproj.io/test: "true"
   annotations:
     workflows.argoproj.io/description: |
-      Conditional aartifacts provide a way to choose the output artifacts based on expression.
+      Conditional artifacts provide a way to choose the output artifacts based on expression.
 
       In this example the main template has two steps which will run conditionall using `when` .
 

--- a/examples/workflows/upstream/volumes_pvc.py
+++ b/examples/workflows/upstream/volumes_pvc.py
@@ -1,0 +1,83 @@
+"""
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: volumes-pvc-
+spec:
+  entrypoint: volumes-pvc-example
+  volumeClaimTemplates:
+  - metadata:
+      name: workdir
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 1Gi
+
+  templates:
+  - name: volumes-pvc-example
+    steps:
+    - - name: generate
+        template: whalesay
+    - - name: print
+        template: print-message
+
+  - name: whalesay
+    container:
+      image: docker/whalesay:latest
+      command: [sh, -c]
+      args: ["echo generating message in volume; cowsay hello world | tee /mnt/vol/hello_world.txt"]
+      volumeMounts:
+      - name: workdir
+        mountPath: /mnt/vol
+
+  - name: print-message
+    container:
+      image: alpine:latest
+      command: [sh, -c]
+      args: ["echo getting message from volume; find /mnt/vol; cat /mnt/vol/hello_world.txt"]
+      volumeMounts:
+      - name: workdir
+        mountPath: /mnt/vol
+"""
+
+from hera.workflows import Workflow, Volume, Container, Steps, models as m
+
+with Workflow(
+    generate_name="volumes-pvc-",
+    entrypoint="volumes-pvc-example",
+    volume_claim_templates=[m.PersistentVolumeClaim(
+        metadata=m.ObjectMeta(name="workdir"),
+        spec=m.PersistentVolumeClaimSpec(
+            access_modes=["ReadWriteOnce"],
+            resources=m.ResourceRequirements(
+                requests={"storage": m.Quantity(__root__="1Gi")},
+            )
+        ),
+    )]
+) as w:
+    v = Volume(
+            name="workdir",
+            size="1Gi",
+            mount_path="/mnt/vol",
+            access_modes=["ReadWriteOnce"],
+        )
+    whalesay = Container(
+        name="whalesay",
+        image="docker/whalesay:latest",
+        command=["sh", "-c"],
+        args=[
+            "echo generating message in volume; cowsay hello world | tee /mnt/vol/hello_world.txt"
+        ],
+        volume_mounts=[m.VolumeMount(name="workdir", mount_path="/mnt/vol")])
+    print_message = Container(
+        name="print-message",
+        image="alpine:latest",
+        command=["sh", "-c"],
+        args=[
+            "echo getting message from volume; find /mnt/vol; cat /mnt/vol/hello_world.txt"
+        ],
+        volume_mounts=[m.VolumeMount(name="workdir", mount_path="/mnt/vol")])
+    with Steps(name="volumes-pvc-example") as s:
+        whalesay(name="generate")
+        print_message(name="print")

--- a/src/hera/shared/global_config.py
+++ b/src/hera/shared/global_config.py
@@ -3,27 +3,17 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
-from typing_extensions import Protocol
-
 if TYPE_CHECKING:
+    from hera.workflows.container import Container
+    from hera.workflows.container_set import ContainerNode, ContainerSet
+    from hera.workflows.cron_workflow import CronWorkflow
+    from hera.workflows.dag import DAG
+    from hera.workflows.resource import Resource
+    from hera.workflows.script import Script
+    from hera.workflows.steps import Step, Steps
     from hera.workflows.task import Task
     from hera.workflows.workflow import Workflow
-
-
-# usage of `pragma: no cover` since coverage will complain that protocols are not tested. These are indeed tested
-# but protocols encourage nominal typing, so any function definition that implements a protocol will not be "noticed"
-# by coverage. See `test_global_config` for test coverage
-class TaskHook(Protocol):  # pragma: no cover
-    def __call__(self, t: Task) -> None:
-        ...
-
-
-# usage of `pragma: no cover` since coverage will complain that protocols are not tested. These are indeed tested
-# but protocols encourage nominal typing, so any function definition that implements a protocol will not be "noticed"
-# by coverage. See `test_global_config` for test coverage
-class WorkflowHook(Protocol):  # pragma: no cover
-    def __call__(self, w: Workflow) -> None:
-        ...
+    from hera.workflows.workflow_template import WorkflowTemplate
 
 
 class _GlobalConfig:
@@ -45,9 +35,23 @@ class _GlobalConfig:
     namespace: Optional[str] = None
     image: str = "python:3.7"
     service_account_name: Optional[str] = None
-    task_post_init_hooks: Tuple[TaskHook, ...] = ()
-    workflow_post_init_hooks: Tuple[WorkflowHook, ...] = ()
     script_command: Optional[List[str]] = ["python"]
+
+    # subbable hooks - these hooks are applied once the workflow is constructed for submission
+    workflow_post_init_hooks: Tuple[Callable[[Workflow], None], ...] = ()
+    cron_workflow_post_init_hooks: Tuple[Callable[[CronWorkflow], None], ...] = ()
+    workflow_template_post_init_hooks: Tuple[Callable[[WorkflowTemplate], None], ...] = ()
+    dag_post_init_hooks: Tuple[Callable[[DAG], None], ...] = ()
+    container_set_post_init_hooks: Tuple[Callable[[ContainerSet], None], ...] = ()
+    steps_post_init_hooks: Tuple[Callable[[Steps], None], ...] = ()
+
+    # subnode hooks - these hooks are applied once the workflow is constructed for submission
+    task_post_init_hooks: Tuple[Callable[[Task], None], ...] = ()
+    resource_post_init_hooks: Tuple[Callable[[Resource], None], ...] = ()
+    container_node_post_init_hooks: Tuple[Callable[[ContainerNode], None], ...] = ()
+    step_post_init_hooks: Tuple[Callable[[Step], None], ...] = ()
+    container_post_init_hooks: Tuple[Callable[[Container], None], ...] = ()
+    script_post_init_hooks: Tuple[Callable[[Script], None], ...] = ()
 
     def reset(self) -> None:
         """Resets the global config container to its initial state"""

--- a/src/hera/workflows/__init__.py
+++ b/src/hera/workflows/__init__.py
@@ -25,7 +25,7 @@ from hera.workflows.dag import DAG
 from hera.workflows.data import Data
 from hera.workflows.env import ConfigMapEnv, Env, FieldEnv, ResourceEnv, SecretEnv
 from hera.workflows.env_from import ConfigMapEnvFrom, SecretEnvFrom
-from hera.workflows.exceptions import InvalidTemplateCall, InvalidType
+from hera.workflows.exceptions import InvalidDispatchType, InvalidTemplateCall, InvalidType
 from hera.workflows.http import HTTP
 from hera.workflows.operator import Operator
 from hera.workflows.parameter import Parameter
@@ -115,6 +115,7 @@ __all__ = [
     "HTTPArtifact",
     "HostPathVolume",
     "ISCSIVolume",
+    "InvalidDispatchType",
     "InvalidTemplateCall",
     "InvalidType",
     "NFSVolume",

--- a/src/hera/workflows/_mixins.py
+++ b/src/hera/workflows/_mixins.py
@@ -28,6 +28,7 @@ from hera.workflows.models import (
     Metrics,
     Outputs as ModelOutputs,
     Parameter as ModelParameter,
+    PersistentVolumeClaim,
     Plugin,
     PodSecurityContext,
     Probe,
@@ -44,7 +45,7 @@ from hera.workflows.models import (
 from hera.workflows.parameter import Parameter
 from hera.workflows.resources import Resources
 from hera.workflows.user_container import UserContainer
-from hera.workflows.volume import _BaseVolume
+from hera.workflows.volume import Volume, _BaseVolume
 
 Inputs = Union[ModelInputs, List[Union[Parameter, ModelParameter, Artifact, ModelArtifact, Dict[str, Any]]]]
 Outputs = Union[ModelOutputs, List[Union[Parameter, ModelParameter, Artifact, ModelArtifact]]]
@@ -251,6 +252,12 @@ class VolumeMountMixin(BaseMixin):
         if self.volumes is None:
             return None
         return [v._build_volume() for v in self.volumes]
+
+    def _build_persistent_volume_claims(self) -> Optional[List[PersistentVolumeClaim]]:
+        if self.volumes is None:
+            return None
+        volumes_with_pv_claims = [v for v in self.volumes if isinstance(v, Volume)]
+        return [v._build_persistent_volume_claim() for v in volumes_with_pv_claims]
 
 
 class ArgumentsMixin(BaseMixin):

--- a/src/hera/workflows/_mixins.py
+++ b/src/hera/workflows/_mixins.py
@@ -45,7 +45,7 @@ from hera.workflows.models import (
 from hera.workflows.parameter import Parameter
 from hera.workflows.resources import Resources
 from hera.workflows.user_container import UserContainer
-from hera.workflows.volume import _BaseVolume, Volume
+from hera.workflows.volume import Volume, _BaseVolume
 
 Inputs = Union[ModelInputs, List[Union[Parameter, ModelParameter, Artifact, ModelArtifact, Dict[str, Any]]]]
 Outputs = Union[ModelOutputs, List[Union[Parameter, ModelParameter, Artifact, ModelArtifact]]]

--- a/src/hera/workflows/container.py
+++ b/src/hera/workflows/container.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import List, Optional
 
+from hera.shared.global_config import GlobalConfig
 from hera.workflows._mixins import (
     CallableTemplateMixin,
     ContainerMixin,
@@ -33,6 +34,10 @@ class Container(
     lifecycle: Optional[Lifecycle] = None
     security_context: Optional[SecurityContext] = None
     working_dir: Optional[str] = None
+
+    def _dispatch_hooks(self):
+        for hook in GlobalConfig.container_post_init_hooks:
+            hook(self)
 
     def _build_container(self) -> _ModelContainer:
         return _ModelContainer(

--- a/src/hera/workflows/container_set.py
+++ b/src/hera/workflows/container_set.py
@@ -18,7 +18,6 @@ from hera.workflows.models import (
     ContainerSetRetryStrategy,
     ContainerSetTemplate as _ModelContainerSetTemplate,
     Template as _ModelTemplate,
-    VolumeMount,
 )
 
 

--- a/src/hera/workflows/container_set.py
+++ b/src/hera/workflows/container_set.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any, List, Optional, Union
 
+from hera.shared.global_config import GlobalConfig
 from hera.workflows._mixins import (
     ContainerMixin,
     ContextMixin,
@@ -22,6 +23,10 @@ from hera.workflows.models import (
 
 
 class ContainerNode(_ModelContainerNode, SubNodeMixin):
+    def _dispatch_hooks(self):
+        for hook in GlobalConfig.container_node_post_init_hooks:
+            hook(self)
+
     def next(self, other: ContainerNode) -> ContainerNode:
         assert issubclass(other.__class__, ContainerNode)
         if other.dependencies is None:

--- a/src/hera/workflows/container_set.py
+++ b/src/hera/workflows/container_set.py
@@ -64,7 +64,6 @@ class ContainerSet(
 ):
     containers: List[ContainerNode] = []
     container_set_retry_strategy: Optional[ContainerSetRetryStrategy] = None
-    volume_mounts: Optional[List[VolumeMount]] = None
 
     def _add_sub(self, node: Any):
         if not isinstance(node, ContainerNode):

--- a/src/hera/workflows/cron_workflow.py
+++ b/src/hera/workflows/cron_workflow.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from types import ModuleType
 from typing import Optional
 
+from hera.shared.global_config import GlobalConfig
 from hera.workflows.models import (
     CreateCronWorkflowRequest,
     CronWorkflow as _ModelCronWorkflow,
@@ -33,7 +34,13 @@ class CronWorkflow(Workflow):
     timezone: Optional[str] = None
     cron_status: Optional[CronWorkflowStatus] = None
 
+    def _dispatch_hooks(self) -> None:
+        for hook in GlobalConfig.cron_workflow_post_init_hooks:
+            hook(self)
+
     def build(self) -> TWorkflow:
+        self._dispatch_hooks()
+
         return _ModelCronWorkflow(
             api_version=self.api_version,
             kind=self.kind,

--- a/src/hera/workflows/dag.py
+++ b/src/hera/workflows/dag.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any, List, Optional, Union
 
+from hera.shared.global_config import GlobalConfig
 from hera.workflows._mixins import ContextMixin, IOMixin, TemplateMixin
 from hera.workflows.exceptions import InvalidType
 from hera.workflows.models import (
@@ -16,6 +17,10 @@ class DAG(IOMixin, TemplateMixin, ContextMixin):
     fail_fast: Optional[bool] = None
     target: Optional[str] = None
     tasks: List[Union[Task, DAGTask]] = []
+
+    def _dispatch_hooks(self):
+        for hook in GlobalConfig.dag_post_init_hooks:
+            hook(self)
 
     def _add_sub(self, node: Any):
         if not isinstance(node, Task):

--- a/src/hera/workflows/exceptions.py
+++ b/src/hera/workflows/exceptions.py
@@ -6,4 +6,8 @@ class InvalidTemplateCall(Exception):
     ...
 
 
-__all__ = ["InvalidType", "InvalidTemplateCall"]
+class InvalidDispatchType(Exception):
+    ...
+
+
+__all__ = ["InvalidType", "InvalidTemplateCall", "InvalidDispatchType"]

--- a/src/hera/workflows/protocol.py
+++ b/src/hera/workflows/protocol.py
@@ -53,3 +53,9 @@ class Subbable(Protocol):
 class Steppable(Protocol):
     def _build_step(self) -> Any:
         ...
+
+
+@runtime_checkable
+class Dispatchable(Protocol):
+    def _dispatch_hooks(self) -> None:
+        ...

--- a/src/hera/workflows/protocol.py
+++ b/src/hera/workflows/protocol.py
@@ -1,4 +1,4 @@
-from typing import Any, Union, Optional, List
+from typing import Any, List, Optional, Union
 
 from typing_extensions import Protocol, runtime_checkable
 
@@ -6,13 +6,13 @@ from hera.workflows.models import (
     ContainerSetTemplate,
     CronWorkflow,
     DAGTemplate,
+    PersistentVolumeClaim,
     ResourceTemplate,
     ScriptTemplate,
     SuspendTemplate,
     Template,
     Workflow,
     WorkflowTemplate,
-    PersistentVolumeClaim,
 )
 
 TTemplate = Union[

--- a/src/hera/workflows/protocol.py
+++ b/src/hera/workflows/protocol.py
@@ -37,6 +37,12 @@ class Templatable(Protocol):
 
 
 @runtime_checkable
+class VolumeClaimable(Protocol):
+    def _build_persistent_volume_claims(self) -> Any:
+        ...
+
+
+@runtime_checkable
 class Subbable(Protocol):
     def _add_sub(self, node: Any) -> Any:
         ...

--- a/src/hera/workflows/protocol.py
+++ b/src/hera/workflows/protocol.py
@@ -1,4 +1,4 @@
-from typing import Any, Union
+from typing import Any, Union, Optional, List
 
 from typing_extensions import Protocol, runtime_checkable
 
@@ -12,6 +12,7 @@ from hera.workflows.models import (
     Template,
     Workflow,
     WorkflowTemplate,
+    PersistentVolumeClaim,
 )
 
 TTemplate = Union[
@@ -38,7 +39,7 @@ class Templatable(Protocol):
 
 @runtime_checkable
 class VolumeClaimable(Protocol):
-    def _build_persistent_volume_claims(self) -> Any:
+    def _build_persistent_volume_claims(self) -> Optional[List[PersistentVolumeClaim]]:
         ...
 
 

--- a/src/hera/workflows/resource.py
+++ b/src/hera/workflows/resource.py
@@ -1,5 +1,6 @@
 from typing import List, Optional
 
+from hera.shared.global_config import GlobalConfig
 from hera.workflows._mixins import IOMixin, SubNodeMixin, TemplateMixin
 from hera.workflows.models import (
     ManifestFrom,
@@ -17,6 +18,10 @@ class Resource(TemplateMixin, SubNodeMixin, IOMixin):
     merge_strategy: Optional[str] = None
     set_owner_reference: Optional[bool] = None
     success_condition: Optional[str] = None
+
+    def _dispatch_hooks(self) -> None:
+        for hook in GlobalConfig.resource_post_init_hooks:
+            hook(self)
 
     def _build_resource_template(self) -> _ModelResourceTemplate:
         return _ModelResourceTemplate(

--- a/src/hera/workflows/script.py
+++ b/src/hera/workflows/script.py
@@ -40,6 +40,10 @@ class Script(
     working_dir: Optional[str] = None
     add_cwd_to_sys_path: bool = True
 
+    def _dispatch_hooks(self):
+        for hook in GlobalConfig.script_post_init_hooks:
+            hook(self)
+
     def _get_param_script_portion(self) -> str:
         """Constructs and returns a script that loads the parameters of the specified arguments. Since Argo passes
         parameters through {{input.parameters.name}} it can be very cumbersome for users to manage that. This creates a

--- a/src/hera/workflows/steps.py
+++ b/src/hera/workflows/steps.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict, List, Optional, Union
 
+from hera.shared.global_config import GlobalConfig
 from hera.workflows._mixins import (
     ArgumentsMixin,
     ContextMixin,
@@ -35,6 +36,10 @@ class Step(
     with_items: Optional[List[_ModelItem]]
     with_param: Optional[str]
     with_sequence: Optional[_ModelSequence]
+
+    def _dispatch_hooks(self):
+        for hook in GlobalConfig.step_post_init_hooks:
+            hook(self)
 
     def _build_as_workflow_step(self) -> _ModelWorkflowStep:
         return _ModelWorkflowStep(
@@ -95,6 +100,10 @@ class Steps(
             List[_ModelWorkflowStep],
         ]
     ] = []
+
+    def _dispatch_hooks(self) -> None:
+        for hook in GlobalConfig.steps_post_init_hooks:
+            hook(self)
 
     def _build_steps(self) -> Optional[List[List[_ModelWorkflowStep]]]:
         steps = []

--- a/src/hera/workflows/task.py
+++ b/src/hera/workflows/task.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import Dict, List, Optional, Union
 
+from hera.shared.global_config import GlobalConfig
 from hera.workflows._mixins import ArgumentsMixin, SubNodeMixin, TemplateMixin
 from hera.workflows.models import (
     ContinueOn,
@@ -43,6 +44,10 @@ class Task(ArgumentsMixin, SubNodeMixin):
     with_items: Optional[List[Item]] = None
     with_param: Optional[str] = None
     with_sequence: Optional[Sequence] = None
+
+    def _dispatch_hooks(self):
+        for hook in GlobalConfig.task_post_init_hooks:
+            hook(self)
 
     def _get_dependency_tasks(self) -> List[str]:
         if self.depends is None:

--- a/src/hera/workflows/volume.py
+++ b/src/hera/workflows/volume.py
@@ -25,8 +25,8 @@ from hera.workflows.models import (
     ISCSIVolumeSource as _ModelISCSIVolumeSource,
     NFSVolumeSource as _ModelNFSVolumeSource,
     ObjectMeta,
+    PersistentVolumeClaim as _ModelPersistentVolumeClaim,
     PersistentVolumeClaimSpec as _ModelPersistentVolumeClaimSpec,
-    PersistentVolumeClaimTemplate as _ModelPersistentVolumeClaimTemplate,
     PersistentVolumeClaimVolumeSource as _ModelPersistentVolumeClaimVolumeSource,
     PhotonPersistentDiskVolumeSource as _ModelPhotonPersistentDiskVolumeSource,
     PortworxVolumeSource as _ModelPortworxVolumeSource,
@@ -84,7 +84,7 @@ class _BaseVolume(_ModelVolumeMount):
             return str(uuid.uuid4())
         return v
 
-    def _build_persistent_volume_claim_template(self) -> _ModelPersistentVolumeClaimTemplate:
+    def _build_persistent_volume_claim(self) -> _ModelPersistentVolumeClaim:
         raise NotImplementedError
 
     def _build_volume(self) -> _ModelVolume:
@@ -459,8 +459,8 @@ class Volume(_BaseVolume, _ModelPersistentVolumeClaimSpec):
             validate_storage_units(cast(str, storage))
         return values
 
-    def _build_persistent_volume_claim_template(self) -> _ModelPersistentVolumeClaimTemplate:
-        return _ModelPersistentVolumeClaimTemplate(
+    def _build_persistent_volume_claim(self) -> _ModelPersistentVolumeClaim:
+        return _ModelPersistentVolumeClaim(
             metadata=self.metadata or ObjectMeta(name=self.name),
             spec=_ModelPersistentVolumeClaimSpec(
                 access_modes=[str(am.value) for am in self.access_modes] if self.access_modes is not None else None,
@@ -475,7 +475,7 @@ class Volume(_BaseVolume, _ModelPersistentVolumeClaimSpec):
         )
 
     def _build_volume(self) -> _ModelVolume:
-        claim = self._build_persistent_volume_claim_template()
+        claim = self._build_persistent_volume_claim()
         assert claim.metadata is not None, "claim metadata is required"
         return _ModelVolume(
             name=self.name,

--- a/src/hera/workflows/volume.py
+++ b/src/hera/workflows/volume.py
@@ -1,6 +1,6 @@
 import uuid
 from enum import Enum
-from typing import List, Optional, cast, Union
+from typing import List, Optional, Union, cast
 
 from pydantic import root_validator, validator
 
@@ -476,7 +476,9 @@ class Volume(_BaseVolume, _ModelPersistentVolumeClaimSpec):
         return _ModelPersistentVolumeClaim(
             metadata=self.metadata or ObjectMeta(name=self.name),
             spec=_ModelPersistentVolumeClaimSpec(
-                access_modes=[str(am.value) for am in self.access_modes] if self.access_modes is not None else None,
+                access_modes=[str(cast(AccessMode, am).value) for am in self.access_modes]
+                if self.access_modes is not None
+                else None,
                 data_source=self.data_source,
                 data_source_ref=self.data_source_ref,
                 resources=self.resources,

--- a/src/hera/workflows/workflow.py
+++ b/src/hera/workflows/workflow.py
@@ -168,13 +168,21 @@ class Workflow(
                     # already existing volume claim templates under the assumption that the user has already set
                     # a claim template on the workflow intentionally, or the user is sharing the same volumes across
                     # different templates
-                    current_volume_claims_map = {claim.metadata.name: claim for claim in self.volume_claim_templates}
-                    new_volume_claims_map = {
-                        claim.metadata.name: claim for claim in template._build_persistent_volume_claims()
-                    }
-                    for claim in new_volume_claims_map.keys():
-                        if claim not in current_volume_claims_map:
-                            self.volume_claim_templates.append(new_volume_claims_map[claim])
+                    current_volume_claims_map = {}
+                    for claim in self.volume_claim_templates:
+                        assert claim.metadata is not None, "expected a workflow volume claim with metadata"
+                        assert claim.metadata.name is not None, "expected a named workflow volume claim"
+                        current_volume_claims_map[claim.metadata.name] = claim
+
+                    new_volume_claims_map = {}
+                    for claim in claims:
+                        assert claim.metadata is not None, "expected a volume claim with metadata"
+                        assert claim.metadata.name is not None, "expected a named volume claim"
+                        new_volume_claims_map[claim.metadata.name] = claim
+
+                    for claim_name in new_volume_claims_map.keys():
+                        if claim_name not in current_volume_claims_map:
+                            self.volume_claim_templates.append(new_volume_claims_map[claim_name])
 
         return _ModelWorkflow(
             api_version=self.api_version,

--- a/src/hera/workflows/workflow.py
+++ b/src/hera/workflows/workflow.py
@@ -47,7 +47,7 @@ from hera.workflows.models import (
     WorkflowTemplateRef,
 )
 from hera.workflows.parameter import Parameter
-from hera.workflows.protocol import Templatable, TTemplate, TWorkflow, VolumeClaimable
+from hera.workflows.protocol import Dispatchable, Templatable, TTemplate, TWorkflow, VolumeClaimable
 from hera.workflows.service import WorkflowsService
 
 _yaml: Optional[ModuleType] = None
@@ -133,6 +133,10 @@ class Workflow(
     # Hera-specific fields
     workflows_service: Optional[WorkflowsService] = None
 
+    def _dispatch_hooks(self):
+        for hook in GlobalConfig.workflow_post_init_hooks:
+            hook(self)
+
     @validator("workflows_service", pre=True, always=True)
     def _set_workflows_service(cls, v):
         if v is None:
@@ -146,8 +150,13 @@ class Workflow(
         return v
 
     def build(self) -> TWorkflow:
+        self._dispatch_hooks()
+
         templates = []
         for template in self.templates:
+            if isinstance(template, Dispatchable):
+                template._dispatch_hooks()
+
             if isinstance(template, Templatable):
                 templates.append(template._build_template())
             elif isinstance(template, get_args(TTemplate)):

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,0 +1,67 @@
+from hera.shared.global_config import GlobalConfig
+from hera.workflows.container import Container
+from hera.workflows.workflow import Workflow
+
+
+def test_container_post_init_hooks():
+    def set_container_default_image(container: Container) -> None:
+        container.image = "test_image"
+
+    GlobalConfig.container_post_init_hooks = (set_container_default_image,)
+
+    with Workflow(name="t") as w:
+        c = Container()
+
+    w.build()
+    assert c.image == "test_image"
+    GlobalConfig.reset()
+
+    def set_container_label(container: Container) -> None:
+        container.labels = {"test": "test"}
+
+    GlobalConfig.container_post_init_hooks = (
+        set_container_default_image,
+        set_container_label,
+    )
+
+    with Workflow(name="t") as w:
+        c = Container()
+
+    w.build()
+    assert c.image == "test_image"
+    assert c.labels["test"] == "test"
+    GlobalConfig.reset()
+
+
+def test_workflow_post_init_hooks():
+    def set_workflow_default_node_selector(workflow: Workflow) -> None:
+        workflow.node_selector = {
+            "domain": "test",
+            "team": "ABC",
+        }
+
+    GlobalConfig.workflow_post_init_hooks = (set_workflow_default_node_selector,)
+
+    with Workflow(name="t") as w:
+        pass
+
+    w.build()
+    assert w.node_selector["domain"] == "test"
+    assert w.node_selector["team"] == "ABC"
+    GlobalConfig.reset()
+
+    def set_workflow_default_labels(workflow: Workflow) -> None:
+        workflow.labels = {
+            "label": "test",
+        }
+
+    GlobalConfig.workflow_post_init_hooks = (set_workflow_default_node_selector, set_workflow_default_labels)
+
+    with Workflow(name="t") as w:
+        pass
+
+    w.build()
+    assert w.node_selector["domain"] == "test"
+    assert w.node_selector["team"] == "ABC"
+    assert w.labels["label"] == "test"
+    GlobalConfig.reset()


### PR DESCRIPTION
When users want to provision volumes dynamically, they have to create both a persistent volume and a persistent volume claim. The claim is set at the Workflow level in order to tell K8S to provision specific volumes for the workflow. It can be cumbersome to set both a volume claim and a volume. This PR allows users to create a Volume() specification on a templatable object. Then, the workflow will automatically create the PVC that is required for the volume that is added by the user. Note that PVCs need to be unique. Hence, the workflow only adds PVCs that are not already added by the user, based on the name of the PVC, since PVC names have to be unique