### PR TITLE
Support dynamic image lookup

### DIFF
--- a/src/hera/global_config.py
+++ b/src/hera/global_config.py
@@ -37,13 +37,13 @@ class _GlobalConfig:
 
     # protected attributes are ones that are computed/go through some light processing upon setting or
     # are processed upon accessing. The rest, which use primitive types, such as `str`, can remain public
+    _image: Union[str, Callable[[], str]] = "python:3.7"
     _token: Union[Optional[str], Callable[[], Optional[str]]] = None
 
     host: Optional[str] = None
     verify_ssl: bool = True
     api_version: str = "argoproj.io/v1alpha1"
     namespace: str = "default"
-    image: str = "python:3.7"
     service_account_name: Optional[str] = None
     task_post_init_hooks: Tuple[TaskHook, ...] = ()
     workflow_post_init_hooks: Tuple[WorkflowHook, ...] = ()
@@ -51,6 +51,18 @@ class _GlobalConfig:
     def reset(self) -> None:
         """Resets the global config container to its initial state"""
         self.__dict__.clear()  # Wipe instance values to fallback to the class defaults
+
+    @property
+    def image(self) -> str:
+        """Return the default image to use for Tasks"""
+        if isinstance(self._image, str):
+            return self._image
+        return self._image()
+
+    @image.setter
+    def image(self, image: Union[str, Callable[[], str]]) -> None:
+        """Set the default image to use for Tasks"""
+        self._image = image
 
     @property
     def token(self) -> Optional[str]:

--- a/tests/test_global_config.py
+++ b/tests/test_global_config.py
@@ -15,8 +15,8 @@ class TestGlobalConfig:
         assert c.token is None
         c.token = '123'
         assert c.token == '123'
-        c.token = lambda: '123'
-        assert c.token == '123'
+        c.token = lambda: 'abc'
+        assert c.token == 'abc'
 
     def test_verify_ssl(self):
         c = _GlobalConfig()
@@ -41,6 +41,8 @@ class TestGlobalConfig:
         assert c.image == "python:3.7"
         c.image = "123"
         assert c.image == "123"
+        c.image = lambda: "abc"
+        assert c.image == "abc"
 
     def test_service_account_name(self):
         c = _GlobalConfig()


### PR DESCRIPTION
I have images that are tagged by git sha. When launching argo jobs from a long running process (eg: a notebook, dev server, etc) and committing code, the default image needs to be pulled dynamically.

This updates `GlobalConfig.image` to support setting a function that will be called on access, similar to `GlobalConfig.token`.
