### PR TITLE
Add support for multiple types to `with_items` and `with_param`

### DIFF
--- a/docs/examples/workflows/upstream/ci_output_artifact.md
+++ b/docs/examples/workflows/upstream/ci_output_artifact.md
@@ -2,89 +2,7 @@
 
 > Note: This example is a replication of an Argo Workflow example in Hera. The upstream example can be [found here](https://github.com/argoproj/argo-workflows/blob/master/examples/ci-output-artifact.yaml).
 
-apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  generateName: ci-output-artifact-
-spec:
-  entrypoint: ci-example
-  # a temporary volume, named workdir, will be used as a working
-  # directory for this workflow. This volume is passed around
-  # from step to step.
-  volumeClaimTemplates:
-  - metadata:
-      name: workdir
-    spec:
-      accessModes: [ "ReadWriteOnce" ]
-      resources:
-        requests:
-          storage: 1Gi
 
-  templates:
-  - name: ci-example
-    steps:
-    - - name: build
-        template: build-golang-example
-    # the test step expands into three parallel steps running
-    # different operating system images. each mounts the workdir
-    # and runs the compiled binary from the build step.
-    - - name: test
-        template: run-hello
-        arguments:
-          parameters:
-          - name: os-image
-            value: "{{item.image}}:{{item.tag}}"
-        withItems:
-        - { image: 'debian', tag: '9.1' }
-        - { image: 'alpine', tag: '3.6' }
-        - { image: 'ubuntu', tag: '17.10' }
-    - - name: release
-        template: release-artifact
-
-
-  - name: build-golang-example
-    inputs:
-      artifacts:
-      - name: code
-        path: /go/src/github.com/golang/example
-        git:
-          repo: https://github.com/golang/example.git
-          revision: cfe12d6
-    container:
-      image: golang:1.8
-      command: [sh, -c]
-      args: ["
-        cd /go/src/github.com/golang/example/hello &&
-        go build -v .
-      "]
-      volumeMounts:
-      - name: workdir
-        mountPath: /go
-  - name: run-hello
-    inputs:
-      parameters:
-      - name: os-image
-    container:
-      image: "{{inputs.parameters.os-image}}"
-      command: [sh, -c]
-      args: ["
-        uname -a ;
-        cat /etc/os-release ;
-        /go/src/github.com/golang/example/hello/hello
-      "]
-      volumeMounts:
-      - name: workdir
-        mountPath: /go
-  - name: release-artifact
-    container:
-      image: alpine:3.8
-      volumeMounts:
-      - name: workdir
-        mountPath: /go
-    outputs:
-      artifacts:
-      - name: release
-        path: /go
 
 ## Hera
 
@@ -166,9 +84,9 @@ with Workflow(
             template=run_hello,
             arguments=[Parameter(name="os-image", value="{{item.image}}:{{item.tag}}")],
             with_items=[
-                m.Item(__root__={"image": "debian", "tag": "9.1"}),
-                m.Item(__root__={"image": "alpine", "tag": "3.6"}),
-                m.Item(__root__={"image": "ubuntu", "tag": "17.10"}),
+                {"image": "debian", "tag": "9.1"},
+                {"image": "alpine", "tag": "3.6"},
+                {"image": "ubuntu", "tag": "17.10"},
             ],
         )
         Step(name="release", template=release_artifact)

--- a/examples/workflows/upstream/ci_output_artifact.py
+++ b/examples/workflows/upstream/ci_output_artifact.py
@@ -1,88 +1,3 @@
-"""
-apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  generateName: ci-output-artifact-
-spec:
-  entrypoint: ci-example
-  # a temporary volume, named workdir, will be used as a working
-  # directory for this workflow. This volume is passed around
-  # from step to step.
-  volumeClaimTemplates:
-  - metadata:
-      name: workdir
-    spec:
-      accessModes: [ "ReadWriteOnce" ]
-      resources:
-        requests:
-          storage: 1Gi
-
-  templates:
-  - name: ci-example
-    steps:
-    - - name: build
-        template: build-golang-example
-    # the test step expands into three parallel steps running
-    # different operating system images. each mounts the workdir
-    # and runs the compiled binary from the build step.
-    - - name: test
-        template: run-hello
-        arguments:
-          parameters:
-          - name: os-image
-            value: "{{item.image}}:{{item.tag}}"
-        withItems:
-        - { image: 'debian', tag: '9.1' }
-        - { image: 'alpine', tag: '3.6' }
-        - { image: 'ubuntu', tag: '17.10' }
-    - - name: release
-        template: release-artifact
-
-
-  - name: build-golang-example
-    inputs:
-      artifacts:
-      - name: code
-        path: /go/src/github.com/golang/example
-        git:
-          repo: https://github.com/golang/example.git
-          revision: cfe12d6
-    container:
-      image: golang:1.8
-      command: [sh, -c]
-      args: ["
-        cd /go/src/github.com/golang/example/hello &&
-        go build -v .
-      "]
-      volumeMounts:
-      - name: workdir
-        mountPath: /go
-  - name: run-hello
-    inputs:
-      parameters:
-      - name: os-image
-    container:
-      image: "{{inputs.parameters.os-image}}"
-      command: [sh, -c]
-      args: ["
-        uname -a ;
-        cat /etc/os-release ;
-        /go/src/github.com/golang/example/hello/hello
-      "]
-      volumeMounts:
-      - name: workdir
-        mountPath: /go
-  - name: release-artifact
-    container:
-      image: alpine:3.8
-      volumeMounts:
-      - name: workdir
-        mountPath: /go
-    outputs:
-      artifacts:
-      - name: release
-        path: /go
-"""
 from hera.workflows import (
     Artifact,
     Container,
@@ -160,9 +75,9 @@ with Workflow(
             template=run_hello,
             arguments=[Parameter(name="os-image", value="{{item.image}}:{{item.tag}}")],
             with_items=[
-                m.Item(__root__={"image": "debian", "tag": "9.1"}),
-                m.Item(__root__={"image": "alpine", "tag": "3.6"}),
-                m.Item(__root__={"image": "ubuntu", "tag": "17.10"}),
+                {"image": "debian", "tag": "9.1"},
+                {"image": "alpine", "tag": "3.6"},
+                {"image": "ubuntu", "tag": "17.10"},
             ],
         )
         Step(name="release", template=release_artifact)

--- a/src/hera/shared/serialization.py
+++ b/src/hera/shared/serialization.py
@@ -1,0 +1,13 @@
+import json
+from typing import Any
+
+MISSING = object()
+
+
+def serialize(value: Any):
+    if value is MISSING:
+        return None
+    elif isinstance(value, str):
+        return value
+    else:
+        return json.dumps(value)  # None serialized as `null`

--- a/src/hera/workflows/_mixins.py
+++ b/src/hera/workflows/_mixins.py
@@ -24,6 +24,7 @@ from hera.workflows.models import (
     ImagePullPolicy,
     Inputs as ModelInputs,
     IntOrString,
+    Item,
     Memoize,
     Metadata,
     Metrics,
@@ -325,8 +326,35 @@ class ParameterMixin(BaseMixin):
     with_param: Optional[Any] = None  # this must be a serializable object, or `hera.workflows.parameter.Parameter`
 
     def _build_with_param(self) -> Optional[str]:
+        if self.with_param is None:
+            return None
+
         if isinstance(self.with_param, Parameter):
             return self.with_param.value
         elif isinstance(self.with_param, str):
             return self.with_param
         return serialize(self.with_param)
+
+
+class ItemMixin(BaseMixin):
+    with_items: Optional[List[Any]] = None
+
+    def _build_with_items(self) -> Optional[List[Item]]:
+        if self.with_items is None:
+            return None
+
+        if isinstance(self.with_items, list):
+            items = []
+            for item in self.with_items:
+                if isinstance(item, Parameter):
+                    items.append(Item(__root__=item.value))
+                elif isinstance(item, str):
+                    items.append(Item(__root__=item))
+                else:
+                    items.append(Item(__root__=serialize(item)))
+            return items
+        elif isinstance(self.with_items, Parameter):
+            return [Item(__root__=self.with_items.value)]
+        elif isinstance(self.with_items, str):
+            return [Item(__root__=self.with_items)]
+        return [Item(__root__=serialize(self.with_items))]

--- a/src/hera/workflows/_mixins.py
+++ b/src/hera/workflows/_mixins.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any, Dict, List, Optional, TypeVar, Union, cast
 
 from hera.shared.global_config import GlobalConfig
+from hera.shared.serialization import serialize
 from hera.workflows._base_model import BaseMixin
 from hera.workflows._context import SubNodeMixin, _context
 from hera.workflows.artifact import Artifact
@@ -301,7 +302,7 @@ class ArgumentsMixin(BaseMixin):
         return model_arguments
 
 
-class CallableTemplateMixin:
+class CallableTemplateMixin(BaseMixin):
     def __call__(self, *args, **kwargs) -> SubNodeMixin:
         try:
             from hera.workflows.steps import Step
@@ -318,3 +319,14 @@ class CallableTemplateMixin:
             pass
 
         raise InvalidTemplateCall("Container is not under a Steps, Parallel, or DAG context")
+
+
+class ParameterMixin(BaseMixin):
+    with_param: Optional[Any] = None  # this must be a serializable object, or `hera.workflows.parameter.Parameter`
+
+    def _build_with_param(self) -> Optional[str]:
+        if isinstance(self.with_param, Parameter):
+            return self.with_param.value
+        elif isinstance(self.with_param, str):
+            return self.with_param
+        return serialize(self.with_param)

--- a/src/hera/workflows/_mixins.py
+++ b/src/hera/workflows/_mixins.py
@@ -337,7 +337,7 @@ class ParameterMixin(BaseMixin):
 
 
 class ItemMixin(BaseMixin):
-    with_items: Optional[List[Any]] = None
+    with_items: Optional[List[Any]] = None  # this must composed of serializable objects
 
     def _build_with_items(self) -> Optional[List[Item]]:
         if self.with_items is None:
@@ -350,6 +350,8 @@ class ItemMixin(BaseMixin):
                     items.append(Item(__root__=item.value))
                 elif isinstance(item, str):
                     items.append(Item(__root__=item))
+                elif isinstance(item, Item):
+                    items.append(item)
                 else:
                     items.append(Item(__root__=serialize(item)))
             return items

--- a/src/hera/workflows/parameter.py
+++ b/src/hera/workflows/parameter.py
@@ -1,21 +1,10 @@
 """Holds input model specifications"""
-import json
 from typing import Any, Optional
 
 from pydantic import root_validator
 
+from hera.shared.serialization import serialize
 from hera.workflows.models import Parameter as _ModelParameter
-
-MISSING = object()
-
-
-def _serialize(value: Any):
-    if value is MISSING:
-        return None
-    elif isinstance(value, str):
-        return value
-    else:
-        return json.dumps(value)  # None serialized as `null`
 
 
 class Parameter(_ModelParameter):
@@ -27,10 +16,10 @@ class Parameter(_ModelParameter):
             raise ValueError("Cannot specify both `value` and `value_from` when instantiating `Parameter`")
 
         if values.get("value") is not None and not isinstance(values.get("value"), str):
-            values["value"] = _serialize(values.get("value"))
+            values["value"] = serialize(values.get("value"))
 
         if values.get("default") is not None and not isinstance(values.get("value"), str):
-            values["default"] = _serialize(values.get("default"))
+            values["default"] = serialize(values.get("default"))
 
         return values
 

--- a/src/hera/workflows/steps.py
+++ b/src/hera/workflows/steps.py
@@ -13,7 +13,6 @@ from hera.workflows._mixins import (
 from hera.workflows.exceptions import InvalidType
 from hera.workflows.models import (
     ContinueOn as _ModelContinueOn,
-    Item as _ModelItem,
     LifecycleHook as _ModelLifecycleHook,
     Sequence as _ModelSequence,
     Template as _ModelTemplate,
@@ -37,7 +36,6 @@ class Step(
     template: Union[str, _ModelTemplate, TemplateMixin]
     template_ref: Optional[_ModelTemplateRef]
     when: Optional[str]
-    with_items: Optional[List[_ModelItem]]
     with_sequence: Optional[_ModelSequence]
 
     def _dispatch_hooks(self):

--- a/src/hera/workflows/steps.py
+++ b/src/hera/workflows/steps.py
@@ -5,6 +5,7 @@ from hera.workflows._mixins import (
     ArgumentsMixin,
     ContextMixin,
     IOMixin,
+    ParameterMixin,
     SubNodeMixin,
     TemplateMixin,
 )
@@ -24,6 +25,7 @@ from hera.workflows.protocol import Steppable
 class Step(
     ArgumentsMixin,
     SubNodeMixin,
+    ParameterMixin,
 ):
     continue_on: Optional[_ModelContinueOn]
     hooks: Optional[Dict[str, _ModelLifecycleHook]]
@@ -34,7 +36,6 @@ class Step(
     template_ref: Optional[_ModelTemplateRef]
     when: Optional[str]
     with_items: Optional[List[_ModelItem]]
-    with_param: Optional[str]
     with_sequence: Optional[_ModelSequence]
 
     def _dispatch_hooks(self):

--- a/src/hera/workflows/steps.py
+++ b/src/hera/workflows/steps.py
@@ -5,6 +5,7 @@ from hera.workflows._mixins import (
     ArgumentsMixin,
     ContextMixin,
     IOMixin,
+    ItemMixin,
     ParameterMixin,
     SubNodeMixin,
     TemplateMixin,
@@ -26,6 +27,7 @@ class Step(
     ArgumentsMixin,
     SubNodeMixin,
     ParameterMixin,
+    ItemMixin,
 ):
     continue_on: Optional[_ModelContinueOn]
     hooks: Optional[Dict[str, _ModelLifecycleHook]]

--- a/src/hera/workflows/task.py
+++ b/src/hera/workflows/task.py
@@ -4,7 +4,7 @@ from enum import Enum
 from typing import Dict, List, Optional, Union
 
 from hera.shared.global_config import GlobalConfig
-from hera.workflows._mixins import ArgumentsMixin, SubNodeMixin, TemplateMixin
+from hera.workflows._mixins import ArgumentsMixin, ParameterMixin, SubNodeMixin, TemplateMixin
 from hera.workflows.models import (
     ContinueOn,
     DAGTask as _ModelDAGTask,
@@ -30,7 +30,7 @@ class TaskResult(Enum):
     all_failed = "AllFailed"
 
 
-class Task(ArgumentsMixin, SubNodeMixin):
+class Task(ArgumentsMixin, SubNodeMixin, ParameterMixin):
     name: str
     continue_on: Optional[ContinueOn] = None
     dependencies: Optional[List[str]] = None
@@ -42,7 +42,6 @@ class Task(ArgumentsMixin, SubNodeMixin):
     inline: Optional[Union[Template, TemplateMixin]] = None
     when: Optional[str] = None
     with_items: Optional[List[Item]] = None
-    with_param: Optional[str] = None
     with_sequence: Optional[Sequence] = None
 
     def _dispatch_hooks(self):

--- a/src/hera/workflows/task.py
+++ b/src/hera/workflows/task.py
@@ -4,11 +4,10 @@ from enum import Enum
 from typing import Dict, List, Optional, Union
 
 from hera.shared.global_config import GlobalConfig
-from hera.workflows._mixins import ArgumentsMixin, ParameterMixin, SubNodeMixin, TemplateMixin
+from hera.workflows._mixins import ArgumentsMixin, ItemMixin, ParameterMixin, SubNodeMixin, TemplateMixin
 from hera.workflows.models import (
     ContinueOn,
     DAGTask as _ModelDAGTask,
-    Item,
     LifecycleHook,
     Sequence,
     Template,
@@ -30,7 +29,7 @@ class TaskResult(Enum):
     all_failed = "AllFailed"
 
 
-class Task(ArgumentsMixin, SubNodeMixin, ParameterMixin):
+class Task(ArgumentsMixin, SubNodeMixin, ParameterMixin, ItemMixin):
     name: str
     continue_on: Optional[ContinueOn] = None
     dependencies: Optional[List[str]] = None
@@ -41,7 +40,6 @@ class Task(ArgumentsMixin, SubNodeMixin, ParameterMixin):
     template_ref: Optional[TemplateRef] = None
     inline: Optional[Union[Template, TemplateMixin]] = None
     when: Optional[str] = None
-    with_items: Optional[List[Item]] = None
     with_sequence: Optional[Sequence] = None
 
     def _dispatch_hooks(self):


### PR DESCRIPTION
At the moment users are forced to use an object called `Item` from the models in order to set the values for `with_items`. In addition, users are forced to serialize the items passed to `with_param` themselves. This PR adds automatic serialization and support for multiple objects in both `with_param` and `with_items`. Note that the use of `with_param` is fully backwards compatible with v4 whereas `with_items` is a new addition