### PR TITLE
use MISSING vs None in parameter inference

### DIFF
--- a/src/hera/task.py
+++ b/src/hera/task.py
@@ -34,7 +34,7 @@ from hera.io import IO
 from hera.memoize import Memoize
 from hera.metric import Metric, Metrics
 from hera.operator import Operator
-from hera.parameter import Parameter
+from hera.parameter import Parameter, MISSING
 from hera.port import ContainerPort
 from hera.resource_template import ResourceTemplate
 from hera.resources import Resources
@@ -701,7 +701,7 @@ class Task(IO):
             if p.default != inspect.Parameter.empty and p.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD:
                 source_signature[p.name] = p.default
             else:
-                source_signature[p.name] = None
+                source_signature[p.name] = MISSING
 
         # Deduce input parameters from function source. Only add those which haven't been explicitly set in inputs
         input_params_names = [p.name for p in self.inputs if isinstance(p, Parameter)]


### PR DESCRIPTION
CC: @JacobHayes 

Problem: when `None` is used for a parameter it gets serialized as `null`. This forces the parameter inference to get a default value of `null` for inferred parameters. Therefore, this leads Hera to not set the non default parameters, which are required to automatically create the Parameter values that have `{{item.X}}` as their defaults when users pass in `with_param`. Hence, the last check in parameter inference raises a key error because no parameters are identified to contain `{{item...`