### PR TITLE
Fix env from

### DIFF
--- a/docs/examples/workflows/env.md
+++ b/docs/examples/workflows/env.md
@@ -1,0 +1,78 @@
+# Env
+
+
+
+
+
+## Hera
+
+```python
+from hera.workflows import (
+    ConfigMapEnv,
+    ConfigMapEnvFrom,
+    Container,
+    Env,
+    ResourceEnv,
+    SecretEnv,
+    SecretEnvFrom,
+    Workflow,
+)
+
+with Workflow(generate_name="secret-env-from-", entrypoint="whalesay") as w:
+    whalesay = Container(
+        image="docker/whalesay:latest",
+        command=["cowsay"],
+        env_from=[
+            SecretEnvFrom(prefix="abc", name="secret", optional=False),
+            ConfigMapEnvFrom(prefix="abc", name="configmap", optional=False),
+        ],
+        env=[
+            Env(name="test", value="1"),
+            SecretEnv(name="s1", secret_key="s1", secret_name="abc"),
+            ResourceEnv(name="r1", resource="abc"),
+            ConfigMapEnv(name="c1", config_map_key="c1", config_map_name="abc"),
+        ],
+    )
+```
+
+## YAML
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: secret-env-from-
+spec:
+  entrypoint: whalesay
+  templates:
+  - container:
+      command:
+      - cowsay
+      env:
+      - name: test
+        value: '1'
+      - name: s1
+        valueFrom:
+          secretKeyRef:
+            key: s1
+            name: abc
+      - name: r1
+        valueFrom:
+          resourceFieldRef:
+            resource: abc
+      - name: c1
+        valueFrom:
+          configMapKeyRef:
+            key: c1
+            name: abc
+      envFrom:
+      - prefix: abc
+        secretRef:
+          name: secret
+          optional: false
+      - configMapRef:
+          name: configmap
+          optional: false
+        prefix: abc
+      image: docker/whalesay:latest
+```

--- a/docs/examples/workflows/env_from.md
+++ b/docs/examples/workflows/env_from.md
@@ -1,0 +1,46 @@
+# Env From
+
+
+
+
+
+## Hera
+
+```python
+from hera.workflows import ConfigMapEnvFrom, Container, SecretEnvFrom, Workflow
+
+with Workflow(generate_name="secret-env-from-", entrypoint="whalesay") as w:
+    whalesay = Container(
+        image="docker/whalesay:latest",
+        command=["cowsay"],
+        env_from=[
+            SecretEnvFrom(prefix="abc", name="secret", optional=False),
+            ConfigMapEnvFrom(prefix="abc", name="configmap", optional=False),
+        ],
+    )
+```
+
+## YAML
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: secret-env-from-
+spec:
+  entrypoint: whalesay
+  templates:
+  - container:
+      command:
+      - cowsay
+      envFrom:
+      - prefix: abc
+        secretRef:
+          name: secret
+          optional: false
+      - configMapRef:
+          name: configmap
+          optional: false
+        prefix: abc
+      image: docker/whalesay:latest
+```

--- a/examples/workflows/env-from.yaml
+++ b/examples/workflows/env-from.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: secret-env-from-
+spec:
+  entrypoint: whalesay
+  templates:
+  - container:
+      command:
+      - cowsay
+      envFrom:
+      - prefix: abc
+        secretRef:
+          name: secret
+          optional: false
+      - configMapRef:
+          name: configmap
+          optional: false
+        prefix: abc
+      image: docker/whalesay:latest

--- a/examples/workflows/env.py
+++ b/examples/workflows/env.py
@@ -1,0 +1,26 @@
+from hera.workflows import (
+    ConfigMapEnv,
+    ConfigMapEnvFrom,
+    Container,
+    Env,
+    ResourceEnv,
+    SecretEnv,
+    SecretEnvFrom,
+    Workflow,
+)
+
+with Workflow(generate_name="secret-env-from-", entrypoint="whalesay") as w:
+    whalesay = Container(
+        image="docker/whalesay:latest",
+        command=["cowsay"],
+        env_from=[
+            SecretEnvFrom(prefix="abc", name="secret", optional=False),
+            ConfigMapEnvFrom(prefix="abc", name="configmap", optional=False),
+        ],
+        env=[
+            Env(name="test", value="1"),
+            SecretEnv(name="s1", secret_key="s1", secret_name="abc"),
+            ResourceEnv(name="r1", resource="abc"),
+            ConfigMapEnv(name="c1", config_map_key="c1", config_map_name="abc"),
+        ],
+    )

--- a/examples/workflows/env.yaml
+++ b/examples/workflows/env.yaml
@@ -1,0 +1,37 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: secret-env-from-
+spec:
+  entrypoint: whalesay
+  templates:
+  - container:
+      command:
+      - cowsay
+      env:
+      - name: test
+        value: '1'
+      - name: s1
+        valueFrom:
+          secretKeyRef:
+            key: s1
+            name: abc
+      - name: r1
+        valueFrom:
+          resourceFieldRef:
+            resource: abc
+      - name: c1
+        valueFrom:
+          configMapKeyRef:
+            key: c1
+            name: abc
+      envFrom:
+      - prefix: abc
+        secretRef:
+          name: secret
+          optional: false
+      - configMapRef:
+          name: configmap
+          optional: false
+        prefix: abc
+      image: docker/whalesay:latest

--- a/examples/workflows/env_from.py
+++ b/examples/workflows/env_from.py
@@ -1,0 +1,11 @@
+from hera.workflows import ConfigMapEnvFrom, Container, SecretEnvFrom, Workflow
+
+with Workflow(generate_name="secret-env-from-", entrypoint="whalesay") as w:
+    whalesay = Container(
+        image="docker/whalesay:latest",
+        command=["cowsay"],
+        env_from=[
+            SecretEnvFrom(prefix="abc", name="secret", optional=False),
+            ConfigMapEnvFrom(prefix="abc", name="configmap", optional=False),
+        ],
+    )

--- a/src/hera/workflows/env_from.py
+++ b/src/hera/workflows/env_from.py
@@ -9,9 +9,7 @@ from hera.workflows.models import (
 
 
 class _BaseEnvFrom(_BaseModel):
-    def __init__(self, prefix: Optional[str] = None) -> None:
-        self.prefix = prefix
-        super().__init__()
+    prefix: Optional[str] = None
 
     def build(self) -> _ModelEnvFromSource:
         """Constructs and returns the Argo EnvFrom specification"""


### PR DESCRIPTION
There's a leftover `__init__` in the base class of `EnvFrom` that prevents instantiation.

See: https://cloud-native.slack.com/archives/C03NRMD9KPY/p1679582090220049

CC: @menzenski 