### PR TITLE
Publish to both `hera-workflows` and `hera` on PyPI

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -4,12 +4,9 @@ on:
   push:
     branches:
       - main
-    paths:
-      - "src/**"
   pull_request:
-    paths:
-      - "src/**"
-
+    branches:
+      - main
 jobs:
   test:
     name: build + test py${{ matrix.python-version }} on ${{ matrix.os }}

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,6 +1,5 @@
 ---
 name: Test PyPI publish
-
 on:
   release:
     types: [prereleased]
@@ -23,4 +22,14 @@ jobs:
         run: |
           poetry build
           poetry config repositories.testpypi https://test.pypi.org/legacy/
-          poetry publish -r testpypi -u __token__ -p ${{ secrets.PYPI_TEST_API_TOKEN }}
+          poetry publish -r testpypi -u __token__ -p ${{ secrets.PYPI_TEST_API_TOKEN_HERA }}
+          rm -rf dist/*
+      - name: Rename hera to hera-workflows for backwards compat
+        run: |
+          sed -i 's/name = "hera"  # project-name/name = "hera-workflows"  # project-name/g' project.toml
+          sed -i 's/name = "hera"  # project-name/name = "hera-workflows"  # project-name/g' src/hera/_version.py
+      - name: Build and publish
+        run: |
+          poetry build
+          poetry config repositories.testpypi https://test.pypi.org/legacy/
+          poetry publish -r testpypi -u __token__ -p ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,18 @@ jobs:
       - name: Build and publish
         env:
           PYPI_USERNAME: __token__
+          PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN_HERA }}
+        run: |
+          poetry build
+          twine upload -u __token__ -p $PYPI_PASSWORD --skip-existing dist/*
+          rm -rf dist/*
+      - name: Rename hera to hera-workflows for backwards compat
+        run: |
+          sed -i 's/name = "hera"  # project-name/name = "hera-workflows"  # project-name/g' project.toml
+          sed -i 's/name = "hera"  # project-name/name = "hera-workflows"  # project-name/g' src/hera/_version.py
+      - name: Build and publish
+        env:
+          PYPI_USERNAME: __token__
           PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: |
           poetry build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Please keep in mind the following guidelines and practices when contributing to 
 1. Your commit must be signed. Hera uses [an application](https://github.com/apps/dco) that enforces the Developer 
    Certificate of Origin (DCO). Currently, a Contributor License Agreement 
    ([CLA](https://github.com/cla-assistant/cla-assistant)) check also appears on submitted pull requests. This can be
-   safely ignored and is **not** a requirement for contributions to hera-workflows. This is an artifact as the Argo Project is slowly migrating projects from CLA to DCO.
+   safely ignored and is **not** a requirement for contributions to hera. This is an artifact as the Argo Project is slowly migrating projects from CLA to DCO.
 1. Use `make format` to format the repository code. `make format` maps to a usage of
    [black](https://github.com/psf/black), and the repository adheres to whatever `black` uses as its strict pep8 format.
    No questions asked!
@@ -45,4 +45,4 @@ In order to add a new workflow test to test Hera functionality, do the following
 ### Code of Conduct
 
 Please be mindful of and adhere to the CNCF's
-[Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md) when contributing to hera-workflows.
+[Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md) when contributing to hera.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,5 +24,3 @@ Since Hera Workflows is built for Argo Workflows, this section offers the Argo W
 
 - see [docs/security.md](https://github.com/argoproj/argo-workflows/blob/master/docs/security.md) for information about
   securing your Argo Workflows instance
-
-

--- a/docs/examples/workflows/env.md
+++ b/docs/examples/workflows/env.md
@@ -4,75 +4,77 @@
 
 
 
-## Hera
 
-```python
-from hera.workflows import (
-    ConfigMapEnv,
-    ConfigMapEnvFrom,
-    Container,
-    Env,
-    ResourceEnv,
-    SecretEnv,
-    SecretEnvFrom,
-    Workflow,
-)
+=== "Hera"
 
-with Workflow(generate_name="secret-env-from-", entrypoint="whalesay") as w:
-    whalesay = Container(
-        image="docker/whalesay:latest",
-        command=["cowsay"],
-        env_from=[
-            SecretEnvFrom(prefix="abc", name="secret", optional=False),
-            ConfigMapEnvFrom(prefix="abc", name="configmap", optional=False),
-        ],
-        env=[
-            Env(name="test", value="1"),
-            SecretEnv(name="s1", secret_key="s1", secret_name="abc"),
-            ResourceEnv(name="r1", resource="abc"),
-            ConfigMapEnv(name="c1", config_map_key="c1", config_map_name="abc"),
-        ],
+    ```python linenums="1"
+    from hera.workflows import (
+        ConfigMapEnv,
+        ConfigMapEnvFrom,
+        Container,
+        Env,
+        ResourceEnv,
+        SecretEnv,
+        SecretEnvFrom,
+        Workflow,
     )
-```
 
-## YAML
+    with Workflow(generate_name="secret-env-from-", entrypoint="whalesay") as w:
+        whalesay = Container(
+            image="docker/whalesay:latest",
+            command=["cowsay"],
+            env_from=[
+                SecretEnvFrom(prefix="abc", name="secret", optional=False),
+                ConfigMapEnvFrom(prefix="abc", name="configmap", optional=False),
+            ],
+            env=[
+                Env(name="test", value="1"),
+                SecretEnv(name="s1", secret_key="s1", secret_name="abc"),
+                ResourceEnv(name="r1", resource="abc"),
+                ConfigMapEnv(name="c1", config_map_key="c1", config_map_name="abc"),
+            ],
+        )
+    ```
 
-```yaml
-apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  generateName: secret-env-from-
-spec:
-  entrypoint: whalesay
-  templates:
-  - container:
-      command:
-      - cowsay
-      env:
-      - name: test
-        value: '1'
-      - name: s1
-        valueFrom:
-          secretKeyRef:
-            key: s1
-            name: abc
-      - name: r1
-        valueFrom:
-          resourceFieldRef:
-            resource: abc
-      - name: c1
-        valueFrom:
-          configMapKeyRef:
-            key: c1
-            name: abc
-      envFrom:
-      - prefix: abc
-        secretRef:
-          name: secret
-          optional: false
-      - configMapRef:
-          name: configmap
-          optional: false
-        prefix: abc
-      image: docker/whalesay:latest
-```
+=== "YAML"
+
+    ```yaml linenums="1"
+    apiVersion: argoproj.io/v1alpha1
+    kind: Workflow
+    metadata:
+      generateName: secret-env-from-
+    spec:
+      entrypoint: whalesay
+      templates:
+      - container:
+          command:
+          - cowsay
+          env:
+          - name: test
+            value: '1'
+          - name: s1
+            valueFrom:
+              secretKeyRef:
+                key: s1
+                name: abc
+          - name: r1
+            valueFrom:
+              resourceFieldRef:
+                resource: abc
+          - name: c1
+            valueFrom:
+              configMapKeyRef:
+                key: c1
+                name: abc
+          envFrom:
+          - prefix: abc
+            secretRef:
+              name: secret
+              optional: false
+          - configMapRef:
+              name: configmap
+              optional: false
+            prefix: abc
+          image: docker/whalesay:latest
+    ```
+

--- a/docs/examples/workflows/env_from.md
+++ b/docs/examples/workflows/env_from.md
@@ -4,43 +4,45 @@
 
 
 
-## Hera
 
-```python
-from hera.workflows import ConfigMapEnvFrom, Container, SecretEnvFrom, Workflow
+=== "Hera"
 
-with Workflow(generate_name="secret-env-from-", entrypoint="whalesay") as w:
-    whalesay = Container(
-        image="docker/whalesay:latest",
-        command=["cowsay"],
-        env_from=[
-            SecretEnvFrom(prefix="abc", name="secret", optional=False),
-            ConfigMapEnvFrom(prefix="abc", name="configmap", optional=False),
-        ],
-    )
-```
+    ```python linenums="1"
+    from hera.workflows import ConfigMapEnvFrom, Container, SecretEnvFrom, Workflow
 
-## YAML
+    with Workflow(generate_name="secret-env-from-", entrypoint="whalesay") as w:
+        whalesay = Container(
+            image="docker/whalesay:latest",
+            command=["cowsay"],
+            env_from=[
+                SecretEnvFrom(prefix="abc", name="secret", optional=False),
+                ConfigMapEnvFrom(prefix="abc", name="configmap", optional=False),
+            ],
+        )
+    ```
 
-```yaml
-apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  generateName: secret-env-from-
-spec:
-  entrypoint: whalesay
-  templates:
-  - container:
-      command:
-      - cowsay
-      envFrom:
-      - prefix: abc
-        secretRef:
-          name: secret
-          optional: false
-      - configMapRef:
-          name: configmap
-          optional: false
-        prefix: abc
-      image: docker/whalesay:latest
-```
+=== "YAML"
+
+    ```yaml linenums="1"
+    apiVersion: argoproj.io/v1alpha1
+    kind: Workflow
+    metadata:
+      generateName: secret-env-from-
+    spec:
+      entrypoint: whalesay
+      templates:
+      - container:
+          command:
+          - cowsay
+          envFrom:
+          - prefix: abc
+            secretRef:
+              name: secret
+              optional: false
+          - configMapRef:
+              name: configmap
+              optional: false
+            prefix: abc
+          image: docker/whalesay:latest
+    ```
+

--- a/docs/examples/workflows/upstream/image_pull_secrets.md
+++ b/docs/examples/workflows/upstream/image_pull_secrets.md
@@ -4,32 +4,34 @@
 
 
 
-## Hera
 
-```python
-from hera.workflows import Container, Workflow
+=== "Hera"
 
-with Workflow(generate_name="hello-world-", image_pull_secrets="docker-registry-secret", entrypoint="whalesay") as w:
-    Container(name="whalesay", image="docker/whalesay:latest", command=["cowsay"], args=["hello world"])
-```
+    ```python linenums="1"
+    from hera.workflows import Container, Workflow
 
-## YAML
+    with Workflow(generate_name="hello-world-", image_pull_secrets="docker-registry-secret", entrypoint="whalesay") as w:
+        Container(name="whalesay", image="docker/whalesay:latest", command=["cowsay"], args=["hello world"])
+    ```
 
-```yaml
-apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  generateName: hello-world-
-spec:
-  entrypoint: whalesay
-  imagePullSecrets:
-  - name: docker-registry-secret
-  templates:
-  - container:
-      args:
-      - hello world
-      command:
-      - cowsay
-      image: docker/whalesay:latest
-    name: whalesay
-```
+=== "YAML"
+
+    ```yaml linenums="1"
+    apiVersion: argoproj.io/v1alpha1
+    kind: Workflow
+    metadata:
+      generateName: hello-world-
+    spec:
+      entrypoint: whalesay
+      imagePullSecrets:
+      - name: docker-registry-secret
+      templates:
+      - container:
+          args:
+          - hello world
+          command:
+          - cowsay
+          image: docker/whalesay:latest
+        name: whalesay
+    ```
+

--- a/docs/generate.py
+++ b/docs/generate.py
@@ -1,7 +1,7 @@
 import re
 import shutil
-from pathlib import Path
 import textwrap
+from pathlib import Path
 
 
 # This code reads the contents at the path which is a python file,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "hera"
+name = "hera"  # project-name
 # The version is automatically substituted by the CI
 version = "0.0.0-dev"
 description = "Hera is a Python framework for constructing and submitting Argo Workflows. The main goal of Hera is to make Argo Workflows more accessible by abstracting away some setup that is typically necessary for constructing Argo workflows."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "hera-workflows"
+name = "hera"
 # The version is automatically substituted by the CI
 version = "0.0.0-dev"
 description = "Hera is a Python framework for constructing and submitting Argo Workflows. The main goal of Hera is to make Argo Workflows more accessible by abstracting away some setup that is typically necessary for constructing Argo workflows."

--- a/src/hera/_version.py
+++ b/src/hera/_version.py
@@ -1,5 +1,9 @@
-# it would be ideal to have all types but pointless to bring in another package for such a brief usage
-import pkg_resources  # type: ignore
+from importlib import metadata
 
-version = pkg_resources.get_distribution("hera-workflows").version
-"""`version` defines the Hera version that is currently installed in the calling environment"""
+name = "hera"  # project-name
+# Used to automatically set version number from github actions
+# as well as not break when being tested locally
+try:
+    version = metadata.version(name)
+except metadata.PackageNotFoundError:  # pragma: no cover
+    version = "0.0.0-dev"


### PR DESCRIPTION
The maintainers behind the original `hera` PyPi project were extremely kind and removed the project from PyPi because it has not been maintained since 2012. Therefore, we claim `hera` and switching from `hera-workflows` to `hera`. I already published rc5 to that project to avoid any potential bot taking the name ahead of this project