### PR TITLE
Update docs to allow giscus for quick discussions

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+{% block content %}
+{{ super() }}
+
+<!-- Giscus -->
+<h2 id="__comments">{{ lang.t("meta.comments") }}</h2>
+
+<script src="https://giscus.app/client.js"
+        data-repo="argoproj-labs/hera-workflows"
+        data-repo-id="R_kgDOGKVL_Q"
+        data-category="Website Discussions"
+        data-category-id="DIC_kwDOGKVL_c4CVX-r"
+        data-mapping="pathname"
+        data-strict="0"
+        data-reactions-enabled="1"
+        data-emit-metadata="0"
+        data-input-position="top"
+        data-theme="preferred_color_scheme"
+        data-lang="en"
+        data-loading="lazy"
+        crossorigin="anonymous"
+        async>
+</script>
+
+{% endblock %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,10 @@ nav:
     - Events:
       - Models: api/events/models.md
 theme:
+  custom_dir: docs/overrides
+  font:
+    text: Roboto
+    code: Roboto Mono
   name: material
   icon:
     repo: fontawesome/brands/github
@@ -40,6 +44,9 @@ theme:
         icon: material/weather-sunny
         name: Switch to dark mode
   features:
+    - navigation.tabs
+    - navigation.tabs.sticky
+    - navigation.top
     - content.code.copy
     - content.code.select
     - search.suggest


### PR DESCRIPTION
Similar to other argo projects, we now have discussions enabled via giscus.

For eg -

<img width="932" alt="image" src="https://user-images.githubusercontent.com/16130816/228372154-c5230bbf-9328-47f8-858b-fd78f3538f03.png">

https://github.com/argoproj-labs/hera-workflows/discussions/524
