### PR TITLE
Rename hera-workflows to hera

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ The general format is:
 ### Added
 
 - `to_yaml`, `to_dict`, and `to_json` on workflows
-- optional PyYAML dependency (`hera-workflows[yaml]`)
+- optional PyYAML dependency (`hera[yaml]`)
 - global default service account
 - global task image
 - global SSL verification flag
@@ -547,8 +547,8 @@ The general format is:
 ### Changed
 
 - underlying SDK of Hera, which moved from `argo-workflows` to the Argo Workflows repository (unpublished on PyPi)
-  Python SDK. This was originally released in https://github.com/argoproj-labs/hera-workflows/pull/38 but the
-  publication process to PyPi failed. A fix was attempted in https://github.com/argoproj-labs/hera-workflows/pull/43
+  Python SDK. This was originally released in https://github.com/argoproj-labs/hera/pull/38 but the
+  publication process to PyPi failed. A fix was attempted in https://github.com/argoproj-labs/hera/pull/43
   but that published a broken version because the `dependency_links` of `setup.py` did not actually install the
   necessary dependency. As a consequence, the release was quickly deleted from PyPi because it was broken. The best
   course of action was to wait for the official release of the new SDK under `argo-workflows==6.0.0`, in collaboration

--- a/README.md
+++ b/README.md
@@ -6,20 +6,20 @@ and its crew were specially protected by the goddess Hera.
 ```
 
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/argoproj-labs/hera-workflows)
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/argoproj-labs/hera)
 
-[![Build](https://github.com/argoproj-labs/hera-workflows/actions/workflows/cicd.yaml/badge.svg)](./.github/workflows/cicd.yaml)
-[![Docs](https://readthedocs.org/projects/hera-workflows/badge/?version=stable)](https://hera-workflows.readthedocs.io/en/stable/?badge=stable)
-[![codecov](https://codecov.io/gh/argoproj-labs/hera-workflows/branch/main/graph/badge.svg?token=x4tvsQRKXP)](https://codecov.io/gh/argoproj-labs/hera-workflows)
+[![Build](https://github.com/argoproj-labs/hera/actions/workflows/cicd.yaml/badge.svg)](./.github/workflows/cicd.yaml)
+[![Docs](https://readthedocs.org/projects/hera/badge/?version=latest)](https://hera.readthedocs.io/en/latest/?badge=latest)
+[![codecov](https://codecov.io/gh/argoproj-labs/hera/branch/main/graph/badge.svg?token=x4tvsQRKXP)](https://codecov.io/gh/argoproj-labs/hera)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-[![Pypi](https://img.shields.io/pypi/v/hera-workflows.svg)](https://pypi.python.org/pypi/hera-workflows)
+[![Pypi](https://img.shields.io/pypi/v/hera.svg)](https://pypi.python.org/pypi/hera)
 [![CondaForge](https://anaconda.org/conda-forge/hera-workflows/badges/version.svg)](https://anaconda.org/conda-forge/hera-workflows)
-[![Versions](https://img.shields.io/pypi/pyversions/hera-workflows.svg)](https://github.com/argoproj-labs/hera-workflows)
+[![Versions](https://img.shields.io/pypi/pyversions/hera.svg)](https://github.com/argoproj-labs/hera)
 
-[![Downloads](https://pepy.tech/badge/hera-workflows)](https://pepy.tech/project/hera-workflows)
-[![Downloads/month](https://pepy.tech/badge/hera-workflows/month)](https://pepy.tech/project/hera-workflows)
-[![Downloads/week](https://pepy.tech/badge/hera-workflows/week)](https://pepy.tech/project/hera-workflows)
+[![Downloads](https://pepy.tech/badge/hera)](https://pepy.tech/project/hera)
+[![Downloads/month](https://pepy.tech/badge/hera/month)](https://pepy.tech/project/hera)
+[![Downloads/week](https://pepy.tech/badge/hera/week)](https://pepy.tech/project/hera)
 
 
 Hera is a Python framework for constructing and submitting Argo Workflows. The main goal of Hera is to make the Argo ecosystem accessible by simplifying workflow construction and submission.
@@ -33,6 +33,8 @@ You can watch the introductory Hera presentation at the "Argo Workflows and Even
 - [Requirements](#requirements)
 - [Installation](#installation)
 - [Examples](#examples)
+    - [Single step script](#single-step-script)
+    - [DAG diamond](#dag-diamond)
 - [Contributing](#contributing)
 - [Comparison](#comparison)
 
@@ -45,15 +47,15 @@ Another option for workflow submission without the authentication layer is using
 > **Note**
 > Since the deprecation of tokens being automatically created for ServiceAccounts and Argo using Bearer tokens in place,
 > it is necessary to use `--auth=server` and/or `--auth=client` when setting up Argo Workflows on Kubernetes v1.24+ 
-> in order for hera-workflows to communicate to the Argo Server.
+> in order for hera to communicate to the Argo Server.
 
 # Installation
 
 | Source                                                         | Command                                                                                                        |
 |----------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------|
-| [PyPi](https://pypi.org/project/hera-workflows/)               | `pip install hera-workflows`                                                                                   |
+| [PyPi](https://pypi.org/project/hera/)               | `pip install hera`                                                                                   |
 | [Conda](https://anaconda.org/conda-forge/hera-workflows)       | `conda install -c conda-forge hera-workflows`                                                                  |
-| [GitHub repo](https://github.com/argoproj-labs/hera-workflows) | `python -m pip install git+https://github.com/argoproj-labs/hera-workflows --ignore-installed`/`pip install .` |
+| [GitHub repo](https://github.com/argoproj-labs/hera) | `python -m pip install git+https://github.com/argoproj-labs/hera --ignore-installed`/`pip install .` |
 
 # Examples
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -30,7 +30,7 @@ Once the pull-request is merged, based on the type label on the merged pull-requ
 
 ## Publishing a new version
 
-Once the maintainers are ready to publish a new version, they can go to the Github draft release at https://github.com/argoproj-labs/hera-workflows/releases.
+Once the maintainers are ready to publish a new version, they can go to the Github draft release at https://github.com/argoproj-labs/hera/releases.
 
 They will find a draft release with the appropriate version and changelog that is only visible to maintainers on the repository.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ All vulnerabilities and associated information will be treated with full confide
 ## Public Disclosure
 
 Security vulnerabilities will be disclosed via [change logs](CHANGELOG.md) and using the
-[GitHub Security Advisories](https://github.com/argoproj-labs/hera-workflows/security/advisories)
+[GitHub Security Advisories](https://github.com/argoproj-labs/hera/security/advisories)
 feature to keep our community well informed, and will credit you for your findings (unless you prefer to stay anonymous,
 of course).
 

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -6,7 +6,7 @@
 <h2 id="__comments">{{ lang.t("meta.comments") }}</h2>
 
 <script src="https://giscus.app/client.js"
-        data-repo="argoproj-labs/hera-workflows"
+        data-repo="argoproj-labs/hera"
         data-repo-id="R_kgDOGKVL_Q"
         data-category="Website Discussions"
         data-category-id="DIC_kwDOGKVL_c4CVX-r"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,8 +53,8 @@ theme:
     - search.share
     - search.highlight
     - content.tabs.link
-repo_url: https://github.com/argoproj-labs/hera-workflows
-repo_name: argoproj-labs/hera-workflows
+repo_url: https://github.com/argoproj-labs/hera
+repo_name: argoproj-labs/hera
 edit_uri: blob/main/docs
 
 extra:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,9 @@ description = "Hera is a Python framework for constructing and submitting Argo W
 authors = ["Flaviu Vadan <flaviu.vadan@dynotx.com>", "Sambhav Kothari <sambhavs.email@gmail.com>", "Elliot Gunton <elliotgunton@gmail.com>"]
 license = "MIT"
 readme = "README.md"
-homepage = "https://github.com/argoproj-labs/hera-workflows"
-repository = "https://github.com/argoproj-labs/hera-workflows"
-documentation = "https://github.com/argoproj-labs/hera-workflows/README.md"
+homepage = "https://github.com/argoproj-labs/hera"
+repository = "https://github.com/argoproj-labs/hera"
+documentation = "https://github.com/argoproj-labs/hera/README.md"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
@@ -25,7 +25,7 @@ packages = [
 ]
 
 [tool.poetry.urls]
-"Bug Tracker" = "https://github.com/argoproj-labs/hera-workflows/issues"
+"Bug Tracker" = "https://github.com/argoproj-labs/hera/issues"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<4"


### PR DESCRIPTION
Given that hera now supports more than just argo-workflows, we are renaming the project to reflect this.

With v5 we are introducing some rudimentary support for argo events.